### PR TITLE
Derive Session Keys

### DIFF
--- a/src/creator.rs
+++ b/src/creator.rs
@@ -412,7 +412,7 @@ impl DataPayloadCreator {
     ///     .set_channel_mask_ack(true)
     ///     .set_data_rate_ack(false)
     ///     .set_tx_power_ack(true);
-    /// let cmds: Vec<&lorawan::maccommands::SerializableMacCommand> = vec![&mac_cmd1, &mac_cmd2];
+    /// let cmds: Vec<&dyn lorawan::maccommands::SerializableMacCommand> = vec![&mac_cmd1, &mac_cmd2];
     /// phy.set_mac_commands(cmds);
     /// ```
     pub fn set_mac_commands<'a>(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -127,6 +127,10 @@ impl <'a, T: AsRef<[u8]>> GenericPhyPayload<T> {
         Ok(result)
     }
 
+    pub fn inner_ref(&self) -> &T {
+        &self.0
+    }
+
     /// Creates a PhyPayload from the decrypted bytes of a JoinAccept.
     ///
     /// # Argument

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,9 +13,6 @@ use aes::block_cipher_trait::generic_array::GenericArray;
 use aes::block_cipher_trait::BlockCipher;
 use aes::Aes128;
 
-//use crypto::aessafe;
-//use crypto::symmetriccipher::BlockEncryptor;
-
 use super::keys;
 use super::maccommands;
 use super::securityhelpers;
@@ -652,4 +649,63 @@ impl FRMMacCommands {
     pub fn mac_commands(&self) -> Result<Vec<maccommands::MacCommand>, String> {
         maccommands::parse_mac_commands(&self.1[..], self.0)
     }
+}
+
+pub fn derive_newskey(app_nonce: &AppNonce, 
+    nwk_addr: &NwkAddr,
+    dev_nonce: &DevNonce,
+    key: &keys::AES128) -> keys::AES128 {
+
+    derive_session_key(0x1,
+        app_nonce,
+        nwk_addr,
+        dev_nonce,
+        key
+        )
+}
+
+pub fn derive_appskey(app_nonce: &AppNonce, 
+    nwk_addr: &NwkAddr,
+    dev_nonce: &DevNonce,
+    key: &keys::AES128) -> keys::AES128 {
+
+    derive_session_key(0x2,
+        app_nonce,
+        nwk_addr,
+        dev_nonce,
+        key
+        )
+}
+
+fn derive_session_key(
+    first_byte: u8,
+    app_nonce: &AppNonce, 
+    nwk_addr: &NwkAddr,
+    dev_nonce: &DevNonce,
+    key: &keys::AES128) -> keys::AES128 {
+
+    let key_arr = GenericArray::from_slice(&key.0);
+    let cipher = Aes128::new(key_arr);
+
+    // note: AppNonce is 24 bit, NetId is 24 bit, DevNonce is 16 bit
+    let (app_nonce_arr, nwk_addr_arr, dev_nonce_arr) 
+        = (app_nonce.as_ref(), nwk_addr.as_ref(), dev_nonce.as_ref());
+
+    let mut block = [0u8; 16];
+    block[0] = first_byte;
+    block[1] = app_nonce_arr[0];
+    block[2] = app_nonce_arr[1];
+    block[3] = app_nonce_arr[2];
+    block[4] = nwk_addr_arr[0];
+    block[5] = nwk_addr_arr[1];
+    block[6] = nwk_addr_arr[2];
+    block[7] = dev_nonce_arr[0];
+    block[8] = dev_nonce_arr[1];
+
+    let mut input = GenericArray::clone_from_slice(&block);
+    cipher.encrypt_block(&mut input);
+
+    let mut output_key = [0u8; 16];
+    output_key.copy_from_slice(&input[0..16]);
+    keys::AES128(output_key)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -114,7 +114,7 @@ impl <'a, T: AsRef<[u8]>> GenericPhyPayload<T> {
                     can_build = DataPayload::can_build_from(payload, true);
                 }
                 MType::UnconfirmedDataDown | MType::ConfirmedDataDown => {
-                    can_build = DataPayload::can_build_from(payload, true);
+                    can_build = DataPayload::can_build_from(payload, false);
                 }
                 _ => return Err("unsupported message type"),
             }
@@ -204,7 +204,7 @@ impl <'a, T: AsRef<[u8]>> GenericPhyPayload<T> {
                 MacPayload::Data(DataPayload::new(bytes, true).unwrap())
             }
             MType::UnconfirmedDataDown | MType::ConfirmedDataDown => {
-                MacPayload::Data(DataPayload::new(bytes, true).unwrap())
+                MacPayload::Data(DataPayload::new(bytes, false).unwrap())
             }
             _ => panic!("unexpected message type passed through the new method"),
         }

--- a/tests/lorawan.rs
+++ b/tests/lorawan.rs
@@ -524,6 +524,53 @@ fn test_join_request_creator() {
 }
 
 #[test]
+fn test_derive_newskey(){
+    let key = AES128(app_key());
+    let data = phy_join_request_payload();
+    let join_request = PhyPayload::new(&data[..]).unwrap();
+    let data = phy_join_accept_payload();
+    let join_accept = PhyPayload::new(&data[..]).unwrap();
+
+    if let (MacPayload::JoinRequest(join_request), MacPayload::JoinAccept(join_accept))
+     = (join_request.mac_payload(), join_accept.mac_payload()) {
+        let newskey = derive_newskey(
+            &join_accept.app_nonce(),
+            &join_accept.net_id(),
+            &join_request.dev_nonce(),
+            &key,
+        );
+        //AppNonce([49, 3e, eb]), NwkAddr([51, fb, a2]), DevNonce([2d, 10])
+        let expect = [0xFE, 0x3D, 0xC0, 0xD5, 0x43, 0xAF, 0xCC, 0x04,
+            0xF9, 0x1F, 0xCB, 0x95, 0xD4, 0x56, 0x22, 0x36];
+        assert_eq!(newskey.0, expect);
+     }
+}
+
+#[test]
+fn test_derive_appskey(){
+    let key = AES128(app_key());
+    let data = phy_join_request_payload();
+    let join_request = PhyPayload::new(&data[..]).unwrap();
+    let data = phy_join_accept_payload();
+    let join_accept = PhyPayload::new(&data[..]).unwrap();
+
+    if let (MacPayload::JoinRequest(join_request), MacPayload::JoinAccept(join_accept))
+     = (join_request.mac_payload(), join_accept.mac_payload()) {
+        let appskey = derive_appskey(
+            &join_accept.app_nonce(),
+            &join_accept.net_id(),
+            &join_request.dev_nonce(),
+            &key,
+        );
+        //AppNonce([49, 3e, eb]), NwkAddr([51, fb, a2]), DevNonce([2d, 10])
+        let expect = [0xD1, 0xDB, 0x68, 0x66, 0x50, 0x46, 0x0D, 0xBB,
+            0x2A, 0x84, 0x6C, 0x24, 0xE9, 0x53, 0xc1, 0x3b];
+
+        assert_eq!(appskey.0, expect);
+     }
+}
+
+#[test]
 fn test_eui64_to_string() {
     let eui = EUI64::new(&[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xff]).unwrap();
     assert_eq!(eui.to_string(), "123456789abcdeff".to_owned());


### PR DESCRIPTION
This provide extra parser functions that help a user derive session keys. I've tested this on live packets and it works.

I can add tests tomorrow if you like.