### PR TITLE
Fix Mac Payloads

### DIFF
--- a/encoding/src/maccommands.rs
+++ b/encoding/src/maccommands.rs
@@ -198,7 +198,7 @@ macro_rules! mac_cmds {
         fn parse_one_mac_cmd<'a, 'b>(data: &'a [u8], uplink: bool) -> Result<(usize, MacCommand<'a>), &'b str> {
             match (data[0], uplink) {
                 $(
-                    ($cid, $uplink) if data.len() > $size => Ok(($size, MacCommand::$name($type::new(&data[1..])?))),
+                    ($cid, $uplink) if data.len() > $size => Ok(($size, MacCommand::$name($type::new(&data[1.. 1 + $size])?))),
                 )*
                 _ => parse_zero_len_mac_cmd(data, uplink)
             }

--- a/encoding/tests/maccommands.rs
+++ b/encoding/tests/maccommands.rs
@@ -252,6 +252,26 @@ fn test_parse_mac_commands_with_multiple_cmds() {
     assert_eq!(commands.next(), Some(expected));
 }
 
+#[test]
+fn test_parse_mac_commands_with_multiple_cmds_with_payloads() {
+    let data = vec![3, 0, 0, 0, 112, 3, 0, 0, 255, 0];
+    let mut commands = parse_mac_commands(&data, false);
+
+    assert_eq!(
+        commands.next(),
+        Some(MacCommand::LinkADRReq(
+            LinkADRReqPayload::new(&[0, 0, 0, 112]).unwrap()
+        ))
+    );
+
+    assert_eq!(
+        commands.next(),
+        Some(MacCommand::LinkADRReq(
+            LinkADRReqPayload::new(&[0, 0, 255, 0]).unwrap()
+        ))
+    );
+}
+
 fn mac_cmds_payload() -> Vec<u8> {
     vec![LinkCheckReqPayload::cid(), LinkADRAnsPayload::cid(), 0x00]
 }


### PR DESCRIPTION
I came across an interesting bug when I was debugging a device's LinkADRReq process with a server. [The specification](https://lora-alliance.org/sites/default/files/2018-05/lorawan1_0_2-20161012_1398_1.pdf) for LinkADRReq is kind of interesting (p.24 l. 33-36):

> The network server may include multiple LinkAdrReq commands within a single downlink message. For the purpose of configuring the end-device channel mask, the end-device will process all contiguous LinkAdrReq messages, in the order present in the downlink message, as a single atomic block command. 

When I listed the FOpts from the downlink, I was seeing:
```
LinkADRReq(LinkADRReqPayload([0, 0, 0, 112, 3, 0, 0, 255, 0]))
LinkADRReq(LinkADRReqPayload([0, 0, 255, 0]))	
```

While multiple LinkADRReq payloads were being parsed, the payload includes the second payload, unfortunately.

The small correction to the `parse_one_mac_cmd` macro resolves the issue. I've added a test case to cover the case as well.