### PR TITLE
Fix FCntUp increment logic

### DIFF
--- a/device/README.md
+++ b/device/README.md
@@ -13,6 +13,7 @@ There are two super-states that the Device can be in:
 State machine diagrams are provided in their respective files: `src/state_machines/no_session` and `src/state_machines/session`   
 
 The following features are implemented:
+* Class A device behavior
 * a radio abstraction layer by the following traits defined here: `radio::PhyRxTx + Timings`
 * the `radio::PhyRxTx` trait enables a state machine design by the implementor
 * a pass through for the LoRaWAN crypto abstraction provided by the lorawan-encoding, paving the way for secure elements and other hardware peripherals
@@ -22,6 +23,7 @@ The following features are implemented:
 * MAC commands are minimally mocked, as a ADRReq is responded with an ADRResp, but not much is done with the actual payload
 
 This is a work in progress and the notable limitations are:
+* Class A behavior only, not B or C
 * OTAA only, no ABP
 * supports US915 only and subband 2 only
 * no retries on Joins or Confirmed packets and the user is instead given **NoAck** and **NoJoinAccept** responses


### PR DESCRIPTION
This fixes an issue where FCnt was automatically incremented. In the case of a confirmed frame that does not receive an ACK, the FCnt should not be incremented, as per the specification:
```
The FCnt is not incremented in case of multiple transmissions of an unconfirmed frame (see NbTrans parameter), or in the case of a confirmed frame that is not acknowledged.
```

The re-transmissions is left to the user, ie: they need to send the same payload to implement a re-transmit after the NoAck response from the stack. This at least makes this possible as the FCnt is otherwise inaccessible to the user.
