### PR TITLE
Crypto Fix

### DIFF
--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -164,11 +164,7 @@ where
     }
 
     pub fn ready_to_send_data(&self) -> bool {
-        if let State::Session(session::Session::Idle(_)) = &self.state {
-            true
-        } else {
-            false
-        }
+        matches!(&self.state, State::Session(session::Session::Idle(_)))
     }
 
     pub fn send(

--- a/device/src/state_machines/session.rs
+++ b/device/src/state_machines/session.rs
@@ -489,7 +489,6 @@ where
                                                 // confirmation (ie: downlink) occurs
                                                 session.fcnt_up_increment();
 
-
                                                 let mut copy = Vec::new();
                                                 copy.extend(encrypted_data.as_bytes());
 
@@ -498,7 +497,10 @@ where
                                                 //      always work when copy bytes from another EncryptedPayload
                                                 // * the decrypt will always work when we have verified MIC previously
                                                 let decrypted =
-                                                    EncryptedDataPayload::new_with_factory(copy, C::default())
+                                                    EncryptedDataPayload::new_with_factory(
+                                                        copy,
+                                                        C::default(),
+                                                    )
                                                     .unwrap()
                                                     .decrypt(
                                                         Some(&session.newskey()),
@@ -571,7 +573,6 @@ where
                     }
                     // Timeout during second RxWindow leads to giving up
                     RxWindow::_2(_) => {
-
                         if !self.confirmed {
                             // if this was not a confirmed frame, we can still
                             // increment the FCnt Up
@@ -580,7 +581,7 @@ where
 
                         let response = if self.confirmed {
                             Ok(Response::NoAck)
-                            // check if FCnt is used up
+                        // check if FCnt is used up
                         } else if self.session.fcnt_up() == (0xFFFF + 1) {
                             // signal that the session is expired
                             // client must know to check for potential data

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -610,13 +610,14 @@ impl<T: AsRef<[u8]>, F: CryptoFactory> EncryptedDataPayload<T, F> {
         if !has_acceptable_len {
             return false;
         }
-        match MHDR(bytes[0]).mtype() {
+
+        matches!(
+            MHDR(bytes[0]).mtype(),
             MType::ConfirmedDataUp
-            | MType::ConfirmedDataDown
-            | MType::UnconfirmedDataUp
-            | MType::UnconfirmedDataDown => true,
-            _ => false,
-        }
+                | MType::ConfirmedDataDown
+                | MType::UnconfirmedDataUp
+                | MType::UnconfirmedDataDown
+        )
     }
 
     /// Verifies that the DataPayload has correct MIC.

--- a/encoding/src/securityhelpers.rs
+++ b/encoding/src/securityhelpers.rs
@@ -65,10 +65,12 @@ pub fn encrypt_frm_data_payload(
     generate_helper_block(phy_payload, 0x01, fcnt, &mut a[..]);
 
     let mut tmp = GenericArray::from_mut_slice(&mut a[..]);
+    let mut ctr = 1;
     for i in 0..len {
         let j = i & 0x0f;
         if j == 0 {
-            a[15] = (i + 1) as u8;
+            a[15] = ctr;
+            ctr+=1;
             tmp = GenericArray::from_mut_slice(&mut a[..]);
             aes_enc.encrypt_block(&mut tmp);
         }

--- a/encoding/src/securityhelpers.rs
+++ b/encoding/src/securityhelpers.rs
@@ -72,7 +72,7 @@ pub fn encrypt_frm_data_payload(
         let j = i & 0x0f;
         if j == 0 {
             a[15] = ctr;
-            ctr+=1;
+            ctr += 1;
             s_block.copy_from_slice(&a);
             aes_enc.encrypt_block(&mut s_block);
         }

--- a/encoding/src/securityhelpers.rs
+++ b/encoding/src/securityhelpers.rs
@@ -64,16 +64,18 @@ pub fn encrypt_frm_data_payload(
     let mut a = [0u8; 16];
     generate_helper_block(phy_payload, 0x01, fcnt, &mut a[..]);
 
-    let mut tmp = GenericArray::from_mut_slice(&mut a[..]);
+    let mut s = [0u8; 16];
+    let mut s_block = GenericArray::from_mut_slice(&mut s[..]);
+
     let mut ctr = 1;
     for i in 0..len {
         let j = i & 0x0f;
         if j == 0 {
             a[15] = ctr;
             ctr+=1;
-            tmp = GenericArray::from_mut_slice(&mut a[..]);
-            aes_enc.encrypt_block(&mut tmp);
+            s_block.copy_from_slice(&a);
+            aes_enc.encrypt_block(&mut s_block);
         }
-        phy_payload[start + i] ^= tmp[j]
+        phy_payload[start + i] ^= s_block[j]
     }
 }


### PR DESCRIPTION
This relates to [the issue filed](https://github.com/ivajloip/rust-lorawan/issues/30) this morning. I noticed that the function `encrypt_frm_data_payload` looks more or less modelled after [PayloadEncrypt from the Loramac Node repo](https://github.com/Lora-net/LoRaMac-node/blob/master/src/mac/LoRaMacCrypto.c#L232). I tried to make the code reflect it more 1-to-1 just for the sake of finding the issue.

While this "fixes" it right now, I think I want to rework this slightly more. I think the core issue lies in the fact that the helper_block is being modified in place during the encryption (`aes_enc.encrypt_block`) while in Loramac Node, the helper block is used repeatedly to derive a new encrypted block. Therefore, I think changing `aes_enc.encrypt_block` to take an input and output block would be better than generating a new helper block every time around this loop.

Anyway, I'll try to put more work into this in the coming days but I wanted to share the progress so we don't duplicate effort @ivajloip 