### PR TITLE
Add support for multiple regions as compile time features

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -17,3 +17,9 @@ lorawan-encoding = { path = "../encoding", default-features = false }
 heapless = "0.5.4"
 as-slice = "*"
 generic-array = "0.14.2"
+
+[features]
+default = ["region+us915"]
+
+"region+us915" = []
+"region+eu868" = []

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -11,8 +11,9 @@ use mac::Mac;
 mod types;
 pub use types::*;
 
-mod us915;
-use us915::Configuration as RegionalConfiguration;
+mod region;
+
+pub use region::Region;
 
 mod state_machines;
 use core::marker::PhantomData;
@@ -130,7 +131,7 @@ where
         appkey: [u8; 16],
         get_random: fn() -> u32,
     ) -> Device<R, C> {
-        let mut region = RegionalConfiguration::new();
+        let mut region = Region::new();
         region.set_subband(2);
 
         Device {

--- a/device/src/mac.rs
+++ b/device/src/mac.rs
@@ -6,7 +6,7 @@ During Uplink assembly, this struct will be inquired to drive construction
 use heapless::consts::*;
 use heapless::Vec;
 
-use super::RegionalConfiguration;
+use super::Region;
 use lorawan_encoding::maccommands::{LinkADRAnsPayload, MacCommand};
 
 #[derive(Default, Debug)]
@@ -38,7 +38,7 @@ impl AdrAnsTrait for AdrAns {
 impl Mac {
     pub fn handle_downlink_macs(
         &mut self,
-        region: &mut RegionalConfiguration,
+        region: &mut Region,
         cmds: &mut lorawan_encoding::maccommands::MacCommandIterator,
     ) {
         for cmd in cmds {

--- a/device/src/radio/types.rs
+++ b/device/src/radio/types.rs
@@ -34,9 +34,9 @@ pub struct RfConfig {
 impl Default for RfConfig {
     fn default() -> RfConfig {
         RfConfig {
-            frequency: 902_300_000,
-            bandwidth: Bandwidth::_500KHZ,
-            spreading_factor: SpreadingFactor::_10,
+            frequency: 868_100_000,
+            bandwidth: Bandwidth::_125KHZ,
+            spreading_factor: SpreadingFactor::_7,
             coding_rate: CodingRate::_4_5,
         }
     }

--- a/device/src/region/eu868.rs
+++ b/device/src/region/eu868.rs
@@ -1,0 +1,134 @@
+#![allow(dead_code)]
+
+use crate::radio::{Bandwidth, CodingRate, SpreadingFactor};
+use lorawan_encoding::maccommands::ChannelMask;
+
+const UPLINK_CHANNEL_MAP: [u32; 9] = [
+    867_100_000,
+    867_300_000,
+    867_500_000,
+    867_700_000,
+    867_900_000,
+    868_100_000,
+    868_300_000,
+    868_500_000,
+    868_800_000,
+];
+
+const DOWNLINK_CHANNEL_MAP: [u32; 10] = [
+    867_100_000,
+    867_300_000,
+    867_500_000,
+    867_700_000,
+    867_900_000,
+    868_100_000,
+    868_300_000,
+    868_500_000,
+    868_800_000,
+    869_525_000,
+];
+
+const RECEIVE_DELAY1: u32 = 1000;
+const RECEIVE_DELAY2: u32 = RECEIVE_DELAY1 + 1000; // must be RECEIVE_DELAY + 1 s
+const JOIN_ACCEPT_DELAY1: u32 = 5000;
+const JOIN_ACCEPT_DELAY2: u32 = 6000;
+const MAX_FCNT_GAP: usize = 16384;
+const ADR_ACK_LIMIT: usize = 64;
+const ADR_ACK_DELAY: usize = 32;
+const ACK_TIMEOUT: usize = 2; // random delay between 1 and 3 seconds
+const DEFAULT_BANDWIDTH: Bandwidth = Bandwidth::_125KHZ;
+const DEFAULT_SPREADING_FACTOR: SpreadingFactor = SpreadingFactor::_7;
+const DEFAULT_CODING_RATE: CodingRate = CodingRate::_4_5;
+const DEFAULT_DBM: i8 = 14;
+
+#[derive(Default)]
+pub struct Configuration {
+    channel: Option<u8>,
+    last_tx: u8,
+}
+
+impl Configuration {
+    pub(crate) fn new() -> Configuration {
+        Self::default()
+    }
+
+    pub(crate) fn set_channel_mask(&mut self, _chmask: ChannelMask) {
+        // one day this should truly be handled
+    }
+
+    pub(crate) fn set_subband(&mut self, _subband: u8) {
+        // No subband in this region
+    }
+
+    pub(crate) fn select_join_frequency(&mut self, random: u8) -> u32 {
+        let channel = if let Some(channel) = &self.channel {
+            if *channel == 0 {
+                random % UPLINK_CHANNEL_MAP.len() as u8
+            } else {
+                *channel - 1
+            }
+        } else {
+            random % UPLINK_CHANNEL_MAP.len() as u8
+        };
+
+        self.channel = Some(channel);
+        self.last_tx = channel;
+        UPLINK_CHANNEL_MAP[channel as usize]
+    }
+
+    pub(crate) fn select_data_frequency(&mut self, random: u8) -> u32 {
+        let channel = if let Some(channel) = &self.channel {
+            if *channel == 0 {
+                random % UPLINK_CHANNEL_MAP.len() as u8
+            } else {
+                *channel - 1
+            }
+        } else {
+            random % UPLINK_CHANNEL_MAP.len() as u8
+        };
+
+        self.channel = Some(channel);
+        self.last_tx = channel;
+        UPLINK_CHANNEL_MAP[channel as usize]
+    }
+
+    pub(crate) fn get_join_accept_frequency1(&self) -> u32 {
+        DOWNLINK_CHANNEL_MAP[self.last_tx as usize]
+    }
+
+    pub(crate) fn get_rxwindow1_frequency(&self) -> u32 {
+        DOWNLINK_CHANNEL_MAP[self.last_tx as usize]
+    }
+
+    pub(crate) fn get_bandwidth(&self) -> Bandwidth {
+        DEFAULT_BANDWIDTH
+    }
+
+    pub(crate) fn get_dbm(&self) -> i8 {
+        DEFAULT_DBM
+    }
+
+    pub(crate) fn get_coding_rate(&self) -> CodingRate {
+        DEFAULT_CODING_RATE
+    }
+
+    pub(crate) fn get_spreading_factor(&self) -> SpreadingFactor {
+        DEFAULT_SPREADING_FACTOR
+    }
+
+    pub(crate) fn get_join_accept_delay1(&self) -> u32 {
+        JOIN_ACCEPT_DELAY1
+    }
+
+    pub(crate) fn get_join_accept_delay2(&self) -> u32 {
+        JOIN_ACCEPT_DELAY2
+    }
+
+    pub(crate) fn get_receive_delay1(&self) -> u32 {
+        RECEIVE_DELAY1
+    }
+
+    pub(crate) fn get_receive_delay2(&self) -> u32 {
+        RECEIVE_DELAY2
+    }
+}

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+
+#[cfg(feature = "region+us915")]
+mod us915;
+
+#[cfg(feature = "region+us915")]
+pub use us915::Configuration as Region;
+
+#[cfg(feature = "region+eu868")]
+mod eu868;
+
+#[cfg(feature = "region+eu868")]
+pub use eu868::Configuration as Region;

--- a/device/src/region/us915.rs
+++ b/device/src/region/us915.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::radio::{Bandwidth, CodingRate, SpreadingFactor};
 use lorawan_encoding::maccommands::ChannelMask;
 
 const UPLINK_CHANNEL_MAP: [[u32; 8]; 8] = [
@@ -104,6 +105,10 @@ const MAX_FCNT_GAP: usize = 16384;
 const ADR_ACK_LIMIT: usize = 64;
 const ADR_ACK_DELAY: usize = 32;
 const ACK_TIMEOUT: usize = 2; // random delay between 1 and 3 seconds
+const DEFAULT_BANDWIDTH: Bandwidth = Bandwidth::_500KHZ;
+const DEFAULT_SPREADING_FACTOR: SpreadingFactor = SpreadingFactor::_10;
+const DEFAULT_CODING_RATE: CodingRate = CodingRate::_4_5;
+const DEFAULT_DBM: i8 = 20;
 
 #[derive(Default)]
 pub struct Configuration {
@@ -112,19 +117,19 @@ pub struct Configuration {
 }
 
 impl Configuration {
-    pub fn new() -> Configuration {
+    pub(crate) fn new() -> Configuration {
         Self::default()
     }
 
-    pub fn set_channel_mask(&mut self, _chmask: ChannelMask) {
+    pub(crate) fn set_channel_mask(&mut self, _chmask: ChannelMask) {
         // one day this should truly be handled
     }
 
-    pub fn set_subband(&mut self, subband: u8) {
+    pub(crate) fn set_subband(&mut self, subband: u8) {
         self.subband = Some(subband);
     }
 
-    pub fn get_join_frequency(&mut self, random: u8) -> u32 {
+    pub(crate) fn select_join_frequency(&mut self, random: u8) -> u32 {
         let subband_channel = random & 0b111;
         let subband = if let Some(subband) = &self.subband {
             subband - 1
@@ -135,7 +140,7 @@ impl Configuration {
         UPLINK_CHANNEL_MAP[subband as usize][subband_channel as usize]
     }
 
-    pub fn get_data_frequency(&mut self, random: u8) -> u32 {
+    pub(crate) fn select_data_frequency(&mut self, random: u8) -> u32 {
         let subband_channel = random & 0b111;
         let subband = if let Some(subband) = &self.subband {
             subband - 1
@@ -146,27 +151,43 @@ impl Configuration {
         UPLINK_CHANNEL_MAP[subband as usize][subband_channel as usize]
     }
 
-    pub fn get_join_accept_frequency1(&self) -> u32 {
+    pub(crate) fn get_join_accept_frequency1(&self) -> u32 {
         DOWNLINK_CHANNEL_MAP[self.last_tx.1 as usize]
     }
 
-    pub fn get_rxwindow1_frequency(&self) -> u32 {
+    pub(crate) fn get_rxwindow1_frequency(&self) -> u32 {
         DOWNLINK_CHANNEL_MAP[self.last_tx.1 as usize]
     }
 
-    pub fn get_join_accept_delay1(&self) -> u32 {
+    pub(crate) fn get_bandwidth(&self) -> Bandwidth {
+        DEFAULT_BANDWIDTH
+    }
+
+    pub(crate) fn get_dbm(&self) -> i8 {
+        DEFAULT_DBM
+    }
+
+    pub(crate) fn get_coding_rate(&self) -> CodingRate {
+        DEFAULT_CODING_RATE
+    }
+
+    pub(crate) fn get_spreading_factor(&self) -> SpreadingFactor {
+        DEFAULT_SPREADING_FACTOR
+    }
+
+    pub(crate) fn get_join_accept_delay1(&self) -> u32 {
         JOIN_ACCEPT_DELAY1
     }
 
-    pub fn get_join_accept_delay2(&self) -> u32 {
+    pub(crate) fn get_join_accept_delay2(&self) -> u32 {
         JOIN_ACCEPT_DELAY2
     }
 
-    pub fn get_receive_delay1(&self) -> u32 {
+    pub(crate) fn get_receive_delay1(&self) -> u32 {
         RECEIVE_DELAY1
     }
 
-    pub fn get_receive_delay2(&self) -> u32 {
+    pub(crate) fn get_receive_delay2(&self) -> u32 {
         RECEIVE_DELAY2
     }
 }

--- a/device/src/state_machines/mod.rs
+++ b/device/src/state_machines/mod.rs
@@ -8,7 +8,7 @@ pub mod session;
 pub struct Shared<R: radio::PhyRxTx + Timings> {
     radio: R,
     credentials: Credentials,
-    region: RegionalConfiguration,
+    region: Region,
     mac: Mac,
     // TODO: do something nicer for randomness
     get_random: fn() -> u32,
@@ -33,7 +33,7 @@ impl<R: radio::PhyRxTx + Timings> Shared<R> {
     pub fn new(
         radio: R,
         credentials: Credentials,
-        region: RegionalConfiguration,
+        region: Region,
         mac: Mac,
         get_random: fn() -> u32,
         buffer: Vec<u8, U256>,

--- a/device/src/state_machines/no_session.rs
+++ b/device/src/state_machines/no_session.rs
@@ -199,15 +199,19 @@ where
 
         // we'll use the rest for frequency and subband selection
         random >>= 16;
-        let frequency = self.shared.region.get_join_frequency(random as u8);
+        let dbm = self.shared.region.get_dbm();
+        let frequency = self.shared.region.select_join_frequency(random as u8);
+        let bandwidth = self.shared.region.get_bandwidth();
+        let spreading_factor = self.shared.region.get_spreading_factor();
+        let coding_rate = self.shared.region.get_coding_rate();
 
         let tx_config = radio::TxConfig {
-            pw: 20,
+            pw: dbm,
             rf: radio::RfConfig {
                 frequency,
-                bandwidth: radio::Bandwidth::_125KHZ,
-                spreading_factor: radio::SpreadingFactor::_10,
-                coding_rate: radio::CodingRate::_4_5,
+                bandwidth,
+                spreading_factor,
+                coding_rate,
             },
         };
         (devnonce_copy, tx_config)
@@ -319,9 +323,9 @@ where
             Event::TimeoutFired => {
                 let rx_config = radio::RfConfig {
                     frequency: self.shared.region.get_join_accept_frequency1(),
-                    bandwidth: radio::Bandwidth::_500KHZ,
-                    spreading_factor: radio::SpreadingFactor::_10,
-                    coding_rate: radio::CodingRate::_4_5,
+                    bandwidth: self.shared.region.get_bandwidth(),
+                    spreading_factor: self.shared.region.get_spreading_factor(),
+                    coding_rate: self.shared.region.get_coding_rate(),
                 };
                 // configure the radio for the RX
                 match self

--- a/device/src/state_machines/session.rs
+++ b/device/src/state_machines/session.rs
@@ -221,16 +221,20 @@ where
                 let fcnt = self.prepare_buffer::<C>(&send_data);
 
                 let random = (self.shared.get_random)();
-                let frequency = self.shared.region.get_data_frequency(random as u8);
+                let dbm = self.shared.region.get_dbm();
+                let frequency = self.shared.region.select_join_frequency(random as u8);
+                let bandwidth = self.shared.region.get_bandwidth();
+                let spreading_factor = self.shared.region.get_spreading_factor();
+                let coding_rate = self.shared.region.get_coding_rate();
 
                 let event: radio::Event<R> = radio::Event::TxRequest(
                     radio::TxConfig {
-                        pw: 20,
+                        pw: dbm,
                         rf: radio::RfConfig {
                             frequency,
-                            bandwidth: radio::Bandwidth::_125KHZ,
-                            spreading_factor: radio::SpreadingFactor::_10,
-                            coding_rate: radio::CodingRate::_4_5,
+                            bandwidth,
+                            spreading_factor,
+                            coding_rate,
                         },
                     },
                     &mut self.shared.buffer,
@@ -379,8 +383,8 @@ where
             Event::TimeoutFired => {
                 let rx_config = radio::RfConfig {
                     frequency: self.shared.region.get_rxwindow1_frequency(),
-                    bandwidth: radio::Bandwidth::_500KHZ,
-                    spreading_factor: radio::SpreadingFactor::_10,
+                    bandwidth: radio::Bandwidth::_125KHZ,
+                    spreading_factor: radio::SpreadingFactor::_7,
                     coding_rate: radio::CodingRate::_4_5,
                 };
                 // configure the radio for the RX


### PR DESCRIPTION
* Add features to select the an instance of region
* Add frequency plan for EU868 region
* Make more radio properties configured from region

With this I am able to use rust-lorawan with the things network in EU frequency bands. There are a few things like RX2 downstream for EU that I don't think will work with this code, but I'm still a LoRa novice so I'm not sure if its acceptable.

Also, I've tried implementing this both using enums, traits and crate features, and the reason for ending up on using features is that I don't think you can reconfigure the region settings anyway, so it seemed like best approach at present.