### PR TITLE
Update to newer versions of aes and cmac crates

### DIFF
--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["lorawan", "iot", "lpwan", "parser", "lightweight"]
 readme = "README.md"
 
 [dependencies]
-aes = { version = "0.4.0", optional = true }
-cmac = { version = "0.3.0", optional = true }
+aes = { version = "0.6.0", optional = true }
+cmac = { version = "0.5.1", optional = true }
 generic-array = "0.14.4"
 
 [dev-dependencies]

--- a/encoding/benches/lorawan.rs
+++ b/encoding/benches/lorawan.rs
@@ -6,7 +6,7 @@
 //
 // author: Ivaylo Petrov <ivajloip@gmail.com>
 
-use aes::block_cipher::{generic_array::GenericArray, NewBlockCipher};
+use aes::cipher::{generic_array::GenericArray, NewBlockCipher};
 use aes::Aes128;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::alloc::System;

--- a/encoding/src/creator.rs
+++ b/encoding/src/creator.rs
@@ -26,10 +26,10 @@ use super::default_crypto::DefaultFactory;
 use super::keys::Decrypter;
 
 #[cfg(any(feature = "with-downlink", feature = "default-crypto"))]
-use aes::block_cipher::generic_array::GenericArray;
+use aes::cipher::generic_array::GenericArray;
 
 #[cfg(feature = "default-crypto")]
-use aes::block_cipher::generic_array::typenum::U256;
+use aes::cipher::generic_array::typenum::U256;
 
 const PIGGYBACK_MAC_COMMANDS_MAX_LEN: usize = 15;
 

--- a/encoding/src/default_crypto.rs
+++ b/encoding/src/default_crypto.rs
@@ -12,7 +12,7 @@ use super::parser::{
     EncryptedJoinAcceptPayload, JoinRequestPayload,
 };
 use super::securityhelpers::generic_array::{typenum::U16, GenericArray};
-use aes::block_cipher::{BlockCipher, NewBlockCipher};
+use aes::cipher::{BlockCipher, NewBlockCipher};
 use aes::Aes128;
 use cmac::crypto_mac::NewMac;
 


### PR DESCRIPTION
This reduces memory usage of generating keys when joining LoRa networks,
which is useful on embedded devices.