### PR TITLE
Remove heapless from radio api

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -14,6 +14,6 @@ description = "A Rust LoRaWAN device stack implementation"
 
 [dependencies]
 lorawan-encoding = { path = "../encoding", default-features = false }
-heapless = "0.5.4"
+heapless = "0.6.1"
 as-slice = "*"
 generic-array = "0.14.2"

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -140,7 +140,7 @@ where
                 region,
                 Mac::default(),
                 get_random,
-                Vec::new(),
+                Default::default(),
             )),
         }
     }

--- a/device/src/radio/mod.rs
+++ b/device/src/radio/mod.rs
@@ -1,17 +1,15 @@
-use heapless::consts::*;
-use heapless::Vec;
-
 mod types;
 pub use types::*;
 
 use super::TimestampMs;
+use heapless::{ArrayLength, Vec};
 
 #[derive(Debug)]
 pub enum Event<'a, R>
 where
     R: PhyRxTx,
 {
-    TxRequest(TxConfig, &'a mut Vec<u8, U256>),
+    TxRequest(TxConfig, &'a mut R::PhyBuf),
     RxRequest(RfConfig),
     CancelRx,
     PhyEvent(R::PhyEvent),
@@ -46,7 +44,26 @@ where
 
 use core::fmt;
 
+pub trait PhyRxTxBuf {
+    fn clear(&mut self);
+    fn extend(&mut self, buf: &[u8]);
+}
+
+impl<N> PhyRxTxBuf for Vec<u8, N>
+where
+    N: ArrayLength<u8>,
+{
+    fn clear(&mut self) {
+        self.clear();
+    }
+
+    fn extend(&mut self, buf: &[u8]) {
+        self.extend_from_slice(buf).unwrap();
+    }
+}
+
 pub trait PhyRxTx {
+    type PhyBuf: AsRef<[u8]> + AsMut<[u8]> + Default + PhyRxTxBuf;
     type PhyEvent: fmt::Debug;
     type PhyError: fmt::Debug;
     type PhyResponse: fmt::Debug;
@@ -54,7 +71,7 @@ pub trait PhyRxTx {
     fn get_mut_radio(&mut self) -> &mut Self;
 
     // we require mutability so we may decrypt in place
-    fn get_received_packet(&mut self) -> &mut Vec<u8, U256>;
+    fn get_received_packet(&mut self) -> &mut Self::PhyBuf;
     fn handle_event(&mut self, event: Event<Self>) -> Result<Response<Self>, Error<Self>>
     where
         Self: core::marker::Sized;

--- a/device/src/state_machines/mod.rs
+++ b/device/src/state_machines/mod.rs
@@ -13,7 +13,7 @@ pub struct Shared<R: radio::PhyRxTx + Timings> {
     mac: Mac,
     // TODO: do something nicer for randomness
     get_random: fn() -> u32,
-    buffer: Vec<u8, U256>,
+    buffer: R::PhyBuf,
     downlink: Option<Downlink>,
     datarate: DR,
 }
@@ -66,7 +66,7 @@ impl<R: radio::PhyRxTx + Timings> Shared<R> {
         region: region::Configuration,
         mac: Mac,
         get_random: fn() -> u32,
-        buffer: Vec<u8, U256>,
+        buffer: R::PhyBuf,
     ) -> Shared<R> {
         let datarate = region.get_default_datarate();
         Shared {

--- a/device/src/state_machines/no_session.rs
+++ b/device/src/state_machines/no_session.rs
@@ -2,6 +2,7 @@ use super::super::session::Session;
 use super::super::State as SuperState;
 use super::super::*;
 use super::{
+    radio::PhyRxTxBuf,
     region::{Frame, Window},
     CommonState, Shared,
 };

--- a/device/src/state_machines/session.rs
+++ b/device/src/state_machines/session.rs
@@ -46,6 +46,7 @@ use super::super::no_session::{NoSession, SessionData};
 use super::super::State as SuperState;
 use super::super::*;
 use super::{
+    radio::PhyRxTxBuf,
     region::{Frame, Window},
     CommonState,
 };
@@ -491,7 +492,7 @@ where
                                         session.fcnt_up_increment();
 
                                         let mut copy = Vec::new();
-                                        copy.extend(encrypted_data.as_bytes());
+                                        copy.extend_from_slice(encrypted_data.as_bytes()).unwrap();
 
                                         // there two unwraps that are sane in their own right
                                         // * making a new EncryptedDataPayload with owned bytes will


### PR DESCRIPTION
This goes further than #38 and attempts to make the radio buffer type configurable.

This makes it easier to depend on different versions of heapless in crates that depend on rust-lorawan. This also eases migration to creates that support const generics, as it would not break dependencies.