### PR TITLE
Remove associated buffer type from radio and pass TX buffer as slice

### DIFF
--- a/device/src/radio/mod.rs
+++ b/device/src/radio/mod.rs
@@ -59,22 +59,22 @@ pub trait PhyRxTx {
 
 pub struct RadioBuffer<'a> {
     packet: &'a mut [u8],
-    len: usize,
+    pos: usize,
 }
 
 impl<'a> RadioBuffer<'a> {
     pub fn new(packet: &'a mut [u8]) -> Self {
-        Self { packet, len: 0 }
+        Self { packet, pos: 0 }
     }
 
     pub fn clear(&mut self) {
-        self.len = 0;
+        self.pos = 0;
     }
 
     pub fn extend_from_slice(&mut self, buf: &[u8]) -> Result<(), ()> {
-        if self.len + buf.len() < self.packet.len() {
-            self.packet[self.len..self.len + buf.len()].copy_from_slice(buf);
-            self.len += buf.len();
+        if self.pos + buf.len() < self.packet.len() {
+            self.packet[self.pos..self.pos + buf.len()].copy_from_slice(buf);
+            self.pos += buf.len();
             Ok(())
         } else {
             Err(())
@@ -84,12 +84,12 @@ impl<'a> RadioBuffer<'a> {
 
 impl AsMut<[u8]> for RadioBuffer<'_> {
     fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.packet[..self.len]
+        &mut self.packet[..self.pos]
     }
 }
 
 impl AsRef<[u8]> for RadioBuffer<'_> {
     fn as_ref(&self) -> &[u8] {
-        &self.packet[..self.len]
+        &self.packet[..self.pos]
     }
 }

--- a/device/src/radio/mod.rs
+++ b/device/src/radio/mod.rs
@@ -2,14 +2,13 @@ mod types;
 pub use types::*;
 
 use super::TimestampMs;
-use heapless::{ArrayLength, Vec};
 
 #[derive(Debug)]
 pub enum Event<'a, R>
 where
     R: PhyRxTx,
 {
-    TxRequest(TxConfig, &'a mut R::PhyBuf),
+    TxRequest(TxConfig, &'a [u8]),
     RxRequest(RfConfig),
     CancelRx,
     PhyEvent(R::PhyEvent),
@@ -44,26 +43,7 @@ where
 
 use core::fmt;
 
-pub trait PhyRxTxBuf {
-    fn clear(&mut self);
-    fn extend(&mut self, buf: &[u8]);
-}
-
-impl<N> PhyRxTxBuf for Vec<u8, N>
-where
-    N: ArrayLength<u8>,
-{
-    fn clear(&mut self) {
-        self.clear();
-    }
-
-    fn extend(&mut self, buf: &[u8]) {
-        self.extend_from_slice(buf).unwrap();
-    }
-}
-
 pub trait PhyRxTx {
-    type PhyBuf: AsRef<[u8]> + AsMut<[u8]> + Default + PhyRxTxBuf;
     type PhyEvent: fmt::Debug;
     type PhyError: fmt::Debug;
     type PhyResponse: fmt::Debug;
@@ -71,8 +51,45 @@ pub trait PhyRxTx {
     fn get_mut_radio(&mut self) -> &mut Self;
 
     // we require mutability so we may decrypt in place
-    fn get_received_packet(&mut self) -> &mut Self::PhyBuf;
+    fn get_received_packet(&mut self) -> &mut [u8];
     fn handle_event(&mut self, event: Event<Self>) -> Result<Response<Self>, Error<Self>>
     where
         Self: core::marker::Sized;
+}
+
+pub struct RadioBuffer<'a> {
+    packet: &'a mut [u8],
+    len: usize,
+}
+
+impl<'a> RadioBuffer<'a> {
+    pub fn new(packet: &'a mut [u8]) -> Self {
+        Self { packet, len: 0 }
+    }
+
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    pub fn extend_from_slice(&mut self, buf: &[u8]) -> Result<(), ()> {
+        if self.len + buf.len() < self.packet.len() {
+            self.packet[self.len..self.len + buf.len()].copy_from_slice(buf);
+            self.len += buf.len();
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl AsMut<[u8]> for RadioBuffer<'_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.packet[..self.len]
+    }
+}
+
+impl AsRef<[u8]> for RadioBuffer<'_> {
+    fn as_ref(&self) -> &[u8] {
+        &self.packet[..self.len]
+    }
 }


### PR DESCRIPTION
This decouples the TX and RX buffer more clearly in the radio API:

* The TX buffer is now passed as a [u8] slice rather than using the
  associated radio type. This makes sense because the radio is only
  given access to this buffer in TxRequest event, in which case it is
  now handed a &[u8] rather than a custom type. It also now only has
  read access to the TX buffer.
* The RX buffer is accessed by lorawan-device after an RxDone event, in
  which case it really only needs a &mut [u8] to parse the packet, and
  -device doesn't really change at all.
* Introduce a RadioBuffer type thats used internally to wrap the
  provided TX buffer slice, with a way to conveniently append to the
  buffer.

There are lots of lifetime arguments being added, in order to allow the
TX buffer to be provided externally. I believe this will be useful in order to fix get_random to use 
proper traits as well. There are some important performance benefits from these changes:

* TX buffer allocation can be done externally to lorawan-device,
  which is crucial for keeping async future stack usage down because the
  size of the buffer will not impact the stack anymore.
* Radio implementations are now free to decide how the RX buffer is
  managed as well, for the same reasons as above.

Although I would ideally like TX and RX to share buffer, I think that would better come in a later PR.