### PR TITLE
Bump `heapless` version

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -14,6 +14,6 @@ description = "A Rust LoRaWAN device stack implementation"
 
 [dependencies]
 lorawan-encoding = { path = "../encoding", default-features = false }
-heapless = "0.6.1"
+heapless = "0.7.5"
 as-slice = "*"
 generic-array = "0.14.2"

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 
-use heapless::consts::*;
 use heapless::Vec;
 
 pub mod radio;
@@ -206,7 +205,7 @@ where
         }
     }
 
-    pub fn take_data_downlink(&mut self) -> Option<DecryptedDataPayload<Vec<u8, U256>>> {
+    pub fn take_data_downlink(&mut self) -> Option<DecryptedDataPayload<Vec<u8, 256>>> {
         self.get_shared().take_data_downlink()
     }
 

--- a/device/src/mac.rs
+++ b/device/src/mac.rs
@@ -3,7 +3,6 @@ This a temporary design where flags will be left about desired MAC uplinks by th
 During Uplink assembly, this struct will be inquired to drive construction
  */
 
-use heapless::consts::*;
 use heapless::Vec;
 
 use super::region;
@@ -50,7 +49,7 @@ impl Mac {
         }
     }
 
-    pub fn get_cmds(&mut self, macs: &mut Vec<MacCommand, U8>) {
+    pub fn get_cmds(&mut self, macs: &mut Vec<MacCommand, 8>) {
         for _ in 0..self.adr_ans.get() {
             macs.push(MacCommand::LinkADRAns(
                 LinkADRAnsPayload::new(&[0x07]).unwrap(),

--- a/device/src/state_machines/mod.rs
+++ b/device/src/state_machines/mod.rs
@@ -20,7 +20,7 @@ pub struct Shared<'a, R: radio::PhyRxTx + Timings> {
 }
 
 enum Downlink {
-    Data(DecryptedDataPayload<Vec<u8, U256>>),
+    Data(DecryptedDataPayload<Vec<u8, 256>>),
     Join(JoinAccept),
 }
 
@@ -43,7 +43,7 @@ impl<'a, R: radio::PhyRxTx + Timings> Shared<'a, R> {
         self.datarate = datarate;
     }
 
-    pub fn take_data_downlink(&mut self) -> Option<DecryptedDataPayload<Vec<u8, U256>>> {
+    pub fn take_data_downlink(&mut self) -> Option<DecryptedDataPayload<Vec<u8, 256>>> {
         if let Some(Downlink::Data(payload)) = self.downlink.take() {
             Some(payload)
         } else {

--- a/device/src/state_machines/session.rs
+++ b/device/src/state_machines/session.rs
@@ -192,7 +192,7 @@ where
         let mut cmds = Vec::new();
         self.shared.mac.get_cmds(&mut cmds);
 
-        let mut dyn_cmds: Vec<&dyn SerializableMacCommand, U8> = Vec::new();
+        let mut dyn_cmds: Vec<&dyn SerializableMacCommand, 8> = Vec::new();
 
         for cmd in &cmds {
             if let Err(_e) = dyn_cmds.push(cmd) {


### PR DESCRIPTION
Bump `heapless` to 0.7.5 and remove the `typenum` uses in internal Vectors.

No real benefit, but better to keep up with the latest data structure versions to avoid surprises with the following ones!