### PR TITLE
Add defmt feature

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -17,3 +17,15 @@ lorawan-encoding = { path = "../encoding", default-features = false }
 heapless = "0.6.1"
 as-slice = "*"
 generic-array = "0.14.2"
+defmt = { version = "0.2.0", optional = true }
+
+[features]
+withdefmt = ["defmt", "lorawan-encoding/defmt"]
+default = []
+# do NOT modify these features
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []

--- a/device/src/radio/types.rs
+++ b/device/src/radio/types.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone)]
 pub enum Bandwidth {
     _125KHz,
@@ -5,6 +6,7 @@ pub enum Bandwidth {
     _500KHz,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone)]
 pub enum SpreadingFactor {
     _7,
@@ -15,6 +17,7 @@ pub enum SpreadingFactor {
     _12,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone)]
 pub enum CodingRate {
     _4_5,
@@ -23,6 +26,7 @@ pub enum CodingRate {
     _4_8,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug)]
 pub struct RfConfig {
     pub frequency: u32,
@@ -31,12 +35,14 @@ pub struct RfConfig {
     pub coding_rate: CodingRate,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug)]
 pub struct TxConfig {
     pub pw: i8,
     pub rf: RfConfig,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug)]
 pub struct RxQuality {
     rssi: i16,

--- a/device/src/types.rs
+++ b/device/src/types.rs
@@ -3,6 +3,7 @@ use lorawan_encoding::keys::AES128;
 pub type AppEui = [u8; 8];
 pub type DevEui = [u8; 8];
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug)]
 pub struct Credentials {
     deveui: DevEui,
@@ -32,6 +33,7 @@ impl Credentials {
     }
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SessionKeys {
     newskey: AES128,
     appskey: AES128,

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 aes = { version = "0.6.0", optional = true }
 cmac = { version = "0.5.1", optional = true }
 generic-array = "0.14.4"
+defmt = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -32,3 +33,11 @@ default-crypto = ["aes", "cmac"]
 with-to-string = []
 
 with-downlink = []
+
+# do NOT modify these features
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []

--- a/encoding/src/keys.rs
+++ b/encoding/src/keys.rs
@@ -8,6 +8,7 @@
 use super::securityhelpers::generic_array::{typenum::U16, GenericArray};
 
 /// AES128 represents 128 bit AES key.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
 pub struct AES128(pub [u8; 16]);
 
@@ -18,6 +19,7 @@ impl From<[u8; 16]> for AES128 {
 }
 
 /// MIC represents LoRaWAN MIC.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
 pub struct MIC(pub [u8; 4]);
 

--- a/encoding/src/maccommands.rs
+++ b/encoding/src/maccommands.rs
@@ -7,6 +7,7 @@
 // author: Ivaylo Petrov <ivajloip@gmail.com>
 
 /// MacCommand represents the enumeration of all LoRaWAN MACCommands.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq)]
 pub enum MacCommand<'a> {
     LinkCheckReq(LinkCheckReqPayload),
@@ -208,60 +209,74 @@ macro_rules! mac_cmds {
 
 mac_cmd_zero_len! {
     /// LinkCheckReqPayload represents the LinkCheckReq LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct LinkCheckReqPayload[cmd=LinkCheckReq, cid=0x02, uplink=true]
 
     /// DutyCycleAnsPayload represents the DutyCycleAns LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct DutyCycleAnsPayload[cmd=DutyCycleAns, cid=0x04, uplink=true]
 
     /// DevStatusReqPayload represents the DevStatusReq LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct DevStatusReqPayload[cmd=DevStatusReq, cid=0x06, uplink=false]
 
     /// RXTimingSetupAnsPayload represents the RXTimingSetupAns LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct RXTimingSetupAnsPayload[cmd=RXTimingSetupAns, cid=0x08, uplink=true]
 }
 
 mac_cmds! {
     /// LinkCheckAnsPayload represents the LinkCheckAns LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct LinkCheckAnsPayload[cmd=LinkCheckAns, cid=0x02, uplink=false, size=2]
 
     /// LinkADRReqPayload represents the LinkADRReq LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct LinkADRReqPayload[cmd=LinkADRReq, cid=0x03, uplink=false, size=4]
 
     /// LinkADRAnsPayload represents the LinkADRAns LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct LinkADRAnsPayload[cmd=LinkADRAns, cid=0x03, uplink=true, size=1]
 
     /// DutyCycleReqPayload represents the DutyCycleReq LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct DutyCycleReqPayload[cmd=DutyCycleReq, cid=0x04, uplink=false, size=1]
 
     /// RXParamSetupReqPayload represents the RXParamSetupReq LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct RXParamSetupReqPayload[cmd=RXParamSetupReq, cid=0x05, uplink=false, size=4]
 
     /// RXParamSetupAnsPayload represents the RXParamSetupAns LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct RXParamSetupAnsPayload[cmd=RXParamSetupAns, cid=0x05, uplink=true, size=1]
 
     /// DevStatusAnsPayload represents the DevStatusAns LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct DevStatusAnsPayload[cmd=DevStatusAns, cid=0x06, uplink=false, size=2]
 
     /// NewChannelReqPayload represents the NewChannelReq LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct NewChannelReqPayload[cmd=NewChannelReq, cid=0x07, uplink=false, size=5]
 
     /// NewChannelAnsPayload represents the NewChannelAns LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct NewChannelAnsPayload[cmd=NewChannelAns, cid=0x07, uplink=true, size=1]
 
     /// RXTimingSetupReqPayload represents the RXTimingSetupReq LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq)]
     struct RXTimingSetupReqPayload[cmd=RXTimingSetupReq, cid=0x08, uplink=false, size=1]
 }


### PR DESCRIPTION
This will make it easier to debug applications using `defmt`. It's implemented only for the main types in `device` and for the keys in `encoding`, which are the parts users see.