### PR TITLE
implement RxDelay handling from Join and MAC Commands

### DIFF
--- a/device/src/mac.rs
+++ b/device/src/mac.rs
@@ -6,9 +6,7 @@ During Uplink assembly, this struct will be inquired to drive construction
 use heapless::Vec;
 
 use super::region;
-use lorawan_encoding::maccommands::{
-    LinkADRAnsPayload, MacCommand, RXTimingSetupAnsPayload, RXTimingSetupReqPayload,
-};
+use lorawan_encoding::maccommands::{LinkADRAnsPayload, MacCommand, RXTimingSetupAnsPayload};
 
 #[derive(Default, Debug)]
 pub struct Mac {

--- a/device/src/mac.rs
+++ b/device/src/mac.rs
@@ -14,7 +14,11 @@ pub struct Mac {
     rx_delay_ans: RxDelayAns,
 }
 
+// multiple AdrAns may happen per downlink
+// so we aggregate how many AdrReqs are required
 type AdrAns = u8;
+// only one RxDelayReq will happen
+// so we only need to implement this as a bool
 type RxDelayAns = bool;
 
 //work around for E0390
@@ -28,8 +32,6 @@ trait MacAnsTrait {
     fn get(&self) -> u8;
 }
 
-// multiple AdrAns may happen per downlink
-// so we aggregate how many AdrReqs are reqired
 impl MacAnsTrait for AdrAns {
     fn add(&mut self) {
         *self += 1;
@@ -42,8 +44,6 @@ impl MacAnsTrait for AdrAns {
     }
 }
 
-// only one RxDelayReq will happen
-// so we only need to implement this as a bool
 impl MacAnsTrait for RxDelayAns {
     fn add(&mut self) {
         *self = true;

--- a/device/src/mac.rs
+++ b/device/src/mac.rs
@@ -6,20 +6,24 @@ During Uplink assembly, this struct will be inquired to drive construction
 use heapless::Vec;
 
 use super::region;
-use lorawan_encoding::maccommands::{LinkADRAnsPayload, MacCommand};
+use lorawan_encoding::maccommands::{
+    LinkADRAnsPayload, MacCommand, RXTimingSetupAnsPayload, RXTimingSetupReqPayload,
+};
 
 #[derive(Default, Debug)]
 pub struct Mac {
     adr_ans: AdrAns,
+    rx_delay_ans: RxDelayAns,
 }
 
 type AdrAns = u8;
+type RxDelayAns = bool;
 
 //work around for E0390
 trait AdrAnsTrait {
     fn add(&mut self);
     fn clear(&mut self);
-    fn get(&mut self) -> u8;
+    fn get(&self) -> u8;
 }
 
 impl AdrAnsTrait for AdrAns {
@@ -29,8 +33,31 @@ impl AdrAnsTrait for AdrAns {
     fn clear(&mut self) {
         *self = 0;
     }
-    fn get(&mut self) -> u8 {
+    fn get(&self) -> u8 {
         *self
+    }
+}
+
+impl AdrAnsTrait for RxDelayAns {
+    fn add(&mut self) {
+        *self = true;
+    }
+    fn clear(&mut self) {
+        *self = false;
+    }
+    fn get(&self) -> u8 {
+        if *self {
+            1
+        } else {
+            0
+        }
+    }
+}
+
+pub fn del_to_delay_ms(del: u8) -> u32 {
+    match del {
+        2..=15 => del as u32 * 1000,
+        _ => region::constants::RECEIVE_DELAY1,
     }
 }
 
@@ -41,12 +68,23 @@ impl Mac {
         cmds: &mut lorawan_encoding::maccommands::MacCommandIterator,
     ) {
         for cmd in cmds {
-            if let MacCommand::LinkADRReq(payload) = cmd {
-                // we ignore DR and TxPwr
-                region.set_channel_mask(payload.channel_mask());
-                self.adr_ans.add();
+            match cmd {
+                MacCommand::LinkADRReq(payload) => {
+                    // we ignore DR and TxPwr
+                    region.set_channel_mask(payload.channel_mask());
+                    self.adr_ans.add();
+                }
+                MacCommand::RXTimingSetupReq(payload) => {
+                    region.set_receive_delay1(del_to_delay_ms(payload.delay()));
+                    self.ack_rx_delay();
+                }
+                _ => (),
             }
         }
+    }
+
+    pub fn ack_rx_delay(&mut self) {
+        self.rx_delay_ans.add();
     }
 
     pub fn get_cmds(&mut self, macs: &mut Vec<MacCommand, 8>) {
@@ -57,5 +95,13 @@ impl Mac {
             .unwrap();
         }
         self.adr_ans.clear();
+
+        if self.rx_delay_ans.get() == 1 {
+            macs.push(MacCommand::RXTimingSetupAns(
+                RXTimingSetupAnsPayload::new(&[]).unwrap(),
+            ))
+            .unwrap();
+        }
+        self.rx_delay_ans.clear();
     }
 }

--- a/device/src/mac.rs
+++ b/device/src/mac.rs
@@ -15,7 +15,7 @@ pub struct Mac {
 }
 
 // multiple AdrAns may happen per downlink
-// so we aggregate how many AdrReqs are required
+// so we aggregate how many AdrAns are required
 type AdrAns = u8;
 // only one RxDelayReq will happen
 // so we only need to implement this as a bool

--- a/device/src/radio/types.rs
+++ b/device/src/radio/types.rs
@@ -69,7 +69,10 @@ pub(crate) struct RadioBuffer<const N: usize> {
 
 impl<const N: usize> RadioBuffer<N> {
     pub(crate) fn new() -> Self {
-        Self { packet: [0; N], pos: 0 }
+        Self {
+            packet: [0; N],
+            pos: 0,
+        }
     }
 
     pub(crate) fn clear(&mut self) {

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -2,7 +2,8 @@
 // generally, we allow upper_case_acronyms to make it match the LoRaWAN naming conventions better
 use lorawan_encoding::maccommands::ChannelMask;
 
-mod constants;
+pub mod constants;
+use crate::mac;
 pub(crate) use crate::radio::*;
 use constants::*;
 
@@ -188,8 +189,11 @@ impl Configuration {
 
     pub(crate) fn process_join_accept<T: core::convert::AsRef<[u8]>, C>(
         &mut self,
+        mac: &mut crate::Mac,
         join_accept: &DecryptedJoinAcceptPayload<T, C>,
     ) -> JoinAccept {
+        self.set_receive_delay1(mac::del_to_delay_ms(join_accept.rx_delay()));
+        mac.ack_rx_delay();
         mut_region_dispatch!(self, process_join_accept, join_accept)
     }
 

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -189,11 +189,9 @@ impl Configuration {
 
     pub(crate) fn process_join_accept<T: core::convert::AsRef<[u8]>, C>(
         &mut self,
-        mac: &mut crate::Mac,
         join_accept: &DecryptedJoinAcceptPayload<T, C>,
     ) -> JoinAccept {
         self.set_receive_delay1(mac::del_to_delay_ms(join_accept.rx_delay()));
-        mac.ack_rx_delay();
         mut_region_dispatch!(self, process_join_accept, join_accept)
     }
 

--- a/device/src/state_machines/no_session.rs
+++ b/device/src/state_machines/no_session.rs
@@ -69,7 +69,9 @@ impl NoSession {
             NoSession::Idle(state) => state.handle_event::<R, C, N>(event, shared),
             NoSession::SendingJoin(state) => state.handle_event::<R, C, N>(event, shared),
             NoSession::WaitingForRxWindow(state) => state.handle_event::<R, C, N>(event, shared),
-            NoSession::WaitingForJoinResponse(state) => state.handle_event::<R, C, N>(event, shared),
+            NoSession::WaitingForJoinResponse(state) => {
+                state.handle_event::<R, C, N>(event, shared)
+            }
         }
     }
 }

--- a/device/src/state_machines/no_session.rs
+++ b/device/src/state_machines/no_session.rs
@@ -337,7 +337,9 @@ impl WaitingForJoinResponse {
                                     Some(credentials) => {
                                         let decrypt = encrypted.decrypt(credentials.appkey());
                                         shared.downlink = Some(super::Downlink::Join(
-                                            shared.region.process_join_accept(&decrypt),
+                                            shared
+                                                .region
+                                                .process_join_accept(&mut shared.mac, &decrypt),
                                         ));
                                         if decrypt.validate_mic(credentials.appkey()) {
                                             let session = SessionData::derive_new(

--- a/device/src/state_machines/no_session.rs
+++ b/device/src/state_machines/no_session.rs
@@ -337,9 +337,7 @@ impl WaitingForJoinResponse {
                                     Some(credentials) => {
                                         let decrypt = encrypted.decrypt(credentials.appkey());
                                         shared.downlink = Some(super::Downlink::Join(
-                                            shared
-                                                .region
-                                                .process_join_accept(&mut shared.mac, &decrypt),
+                                            shared.region.process_join_accept(&decrypt),
                                         ));
                                         if decrypt.validate_mic(credentials.appkey()) {
                                             let session = SessionData::derive_new(

--- a/device/src/state_machines/session.rs
+++ b/device/src/state_machines/session.rs
@@ -414,7 +414,6 @@ impl WaitingForRx {
                             if let Ok(PhyPayload::Data(DataPayload::Encrypted(encrypted_data))) =
                                 lorawan_parse(shared.radio.get_received_packet(), C::default())
                             {
-                                let confirmed = encrypted_data.is_confirmed();
                                 let session = &mut self.session;
                                 if session.devaddr() == &encrypted_data.fhdr().dev_addr() {
                                     let fcnt = encrypted_data.fhdr().fcnt() as u32;
@@ -544,7 +543,11 @@ impl WaitingForRx {
     }
 }
 
-fn data_rxwindow1_timeout<R: radio::PhyRxTx + Timings, C: CryptoFactory + Default, const N: usize>(
+fn data_rxwindow1_timeout<
+    R: radio::PhyRxTx + Timings,
+    C: CryptoFactory + Default,
+    const N: usize,
+>(
     state: Session,
     confirmed: bool,
     timestamp_ms: TimestampMs,

--- a/device/src/state_machines/session.rs
+++ b/device/src/state_machines/session.rs
@@ -414,6 +414,7 @@ impl WaitingForRx {
                             if let Ok(PhyPayload::Data(DataPayload::Encrypted(encrypted_data))) =
                                 lorawan_parse(shared.radio.get_received_packet(), C::default())
                             {
+                                let confirmed = encrypted_data.is_confirmed();
                                 let session = &mut self.session;
                                 if session.devaddr() == &encrypted_data.fhdr().dev_addr() {
                                     let fcnt = encrypted_data.fhdr().fcnt() as u32;

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -541,14 +541,7 @@ pub trait DataHeader {
             self.is_uplink(),
         )
     }
-
-    /// Gives whether the data frame confirmed or not
-    fn is_confirmed(&self) -> bool {
-        let mtype = MHDR(self.as_data_bytes()[0]).mtype();
-
-        mtype == MType::ConfirmedDataUp || mtype == MType::ConfirmedDataDown
-    }
-
+    
     /// Gives whether the payload is uplink or not.
     fn is_uplink(&self) -> bool {
         let mtype = MHDR(self.as_data_bytes()[0]).mtype();

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -541,7 +541,7 @@ pub trait DataHeader {
             self.is_uplink(),
         )
     }
-    
+
     /// Gives whether the payload is uplink or not.
     fn is_uplink(&self) -> bool {
         let mtype = MHDR(self.as_data_bytes()[0]).mtype();

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -542,6 +542,13 @@ pub trait DataHeader {
         )
     }
 
+    /// Gives whether the data frame confirmed or not
+    fn is_confirmed(&self) -> bool {
+        let mtype = MHDR(self.as_data_bytes()[0]).mtype();
+
+        mtype == MType::ConfirmedDataUp || mtype == MType::ConfirmedDataDown
+    }
+
     /// Gives whether the payload is uplink or not.
     fn is_uplink(&self) -> bool {
         let mtype = MHDR(self.as_data_bytes()[0]).mtype();


### PR DESCRIPTION
RxDelay may be configured in the JoinAccept or in a MAC Command attached to a downlink.

This PR parses RxDelay from either of these frame types and saves the delay timing. It enqueues the RXTimingSetupAns for the next uplink.