### PR TITLE
Fix typo in downlink US downlink frequency

### DIFF
--- a/device/src/region/us915/frequencies.rs
+++ b/device/src/region/us915/frequencies.rs
@@ -92,7 +92,7 @@ pub(crate) const UPLINK_CHANNEL_MAP: [[u32; 8]; 9] = [
 ];
 
 pub(crate) const DOWNLINK_CHANNEL_MAP: [u32; 8] = [
-    922_300_000,
+    923_300_000,
     923_900_000,
     924_500_000,
     925_100_000,


### PR DESCRIPTION
Just what it says on the tin, this is a simple typo fix.