### PR TITLE
Add AS923 and IN865 regions

### DIFF
--- a/device/src/region/as923/datarates.rs
+++ b/device/src/region/as923/datarates.rs
@@ -1,0 +1,33 @@
+use super::{Bandwidth, Datarate, SpreadingFactor};
+
+pub(crate) const DATARATES: [Datarate; 7] = [
+    Datarate {
+        spreading_factor: SpreadingFactor::_12,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_11,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_10,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_9,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_250KHz,
+    },
+    //ignore FSK data rate for now
+];

--- a/device/src/region/as923/mod.rs
+++ b/device/src/region/as923/mod.rs
@@ -15,6 +15,7 @@ const AS_DBM: i8 = 16;
 mod datarates;
 use datarates::*;
 
+#[derive(Debug, Copy, Clone)]
 pub enum AS923Subband {
     _1,
     _2,

--- a/device/src/region/as923/mod.rs
+++ b/device/src/region/as923/mod.rs
@@ -15,7 +15,6 @@ const AS_DBM: i8 = 16;
 mod datarates;
 use datarates::*;
 
-#[derive(Debug, Copy, Clone)]
 pub enum AS923Subband {
     _1,
     _2,
@@ -72,21 +71,21 @@ impl RegionHandler for AS923 {
                     if let Some(cf_list) = self.cf_list {
                         let channel = random as usize & 0b111;
                         self.last_tx = channel;
-                        if channel < JOIN_CHANNELS.len() {
-                            JOIN_CHANNELS[channel][self.subband as usize]
+                        if channel < JOIN_CHANNELS[self.subband as usize].len() {
+                            JOIN_CHANNELS[self.subband as usize][channel]
                         } else {
-                            cf_list[channel - JOIN_CHANNELS.len()]
+                            cf_list[channel - JOIN_CHANNELS[self.subband as usize].len()]
                         }
                     } else {
-                        let channel = random as usize % JOIN_CHANNELS.len();
+                        let channel = random as usize % JOIN_CHANNELS[self.subband as usize]len();
                         self.last_tx = channel;
-                        JOIN_CHANNELS[channel][self.subband as usize]
+                        JOIN_CHANNELS[self.subband as usize][channel]
                     }
                 }
                 Frame::Join => {
-                    let channel = random as usize % JOIN_CHANNELS.len();
+                    let channel = random as usize % JOIN_CHANNELS[self.subband as usize].len();
                     self.last_tx = channel;
-                    JOIN_CHANNELS[channel][self.subband as usize]
+                    JOIN_CHANNELS[self.subband as usize][channel]
                 }
             },
         )
@@ -97,13 +96,13 @@ impl RegionHandler for AS923 {
             Window::_1 => {
                 let channel = self.last_tx;
                 if let Some(cf_list) = self.cf_list {
-                    if channel < JOIN_CHANNELS.len() {
-                        JOIN_CHANNELS[channel][self.subband as usize]
+                    if channel < JOIN_CHANNELS[self.subband as usize].len() {
+                        JOIN_CHANNELS[self.subband as usize][channel]
                     } else {
-                        cf_list[channel - JOIN_CHANNELS.len()]
+                        cf_list[channel - JOIN_CHANNELS[self.subband as usize].len()]
                     }
                 } else {
-                    JOIN_CHANNELS[channel][self.subband as usize]
+                    JOIN_CHANNELS[self.subband as usize][channel]
                 }
             }
             Window::_2 => RX2_FREQUENCY[self.subband as usize],

--- a/device/src/region/as923/mod.rs
+++ b/device/src/region/as923/mod.rs
@@ -77,7 +77,7 @@ impl RegionHandler for AS923 {
                             cf_list[channel - JOIN_CHANNELS[self.subband as usize].len()]
                         }
                     } else {
-                        let channel = random as usize % JOIN_CHANNELS[self.subband as usize]len();
+                        let channel = random as usize % JOIN_CHANNELS[self.subband as usize].len();
                         self.last_tx = channel;
                         JOIN_CHANNELS[self.subband as usize][channel]
                     }

--- a/device/src/region/as923/mod.rs
+++ b/device/src/region/as923/mod.rs
@@ -1,0 +1,123 @@
+#![allow(dead_code)]
+use super::*;
+
+const JOIN_CHANNELS: [[u32; 2]; 4] = [
+    [923_200_000, 923_400_000],
+    [921_400_000, 921_600_000],
+    [916_600_000, 916_800_000],
+    [917_300_000, 917_500_000],
+];
+
+const RX2_FREQUENCY: [u32; 4] = [923_200_000, 921_400_000, 916_600_000, 917_300_000];
+
+const AS_DBM: i8 = 16;
+
+mod datarates;
+use datarates::*;
+
+pub enum AS923Subband {
+    _1,
+    _2,
+    _3,
+    _4,
+}
+
+#[allow(clippy::upper_case_acronyms)]
+pub struct AS923 {
+    subband: AS923Subband,
+    last_tx: usize,
+    cf_list: Option<[u32; 5]>,
+}
+
+impl AS923 {
+    pub fn new(subband: AS923Subband) -> AS923 {
+        Self {
+            subband,
+            last_tx: 0,
+            cf_list: None,
+        }
+    }
+}
+
+use super::JoinAccept;
+
+impl RegionHandler for AS923 {
+    fn process_join_accept<T: core::convert::AsRef<[u8]>, C>(
+        &mut self,
+        join_accept: &super::DecryptedJoinAcceptPayload<T, C>,
+    ) -> JoinAccept {
+        let mut new_cf_list = [0, 0, 0, 0, 0];
+        if let Some(CfList::DynamicChannel(cf_list)) = join_accept.c_f_list() {
+            for (index, freq) in cf_list.iter().enumerate() {
+                new_cf_list[index] = freq.value();
+            }
+        }
+        self.cf_list = Some(new_cf_list);
+        JoinAccept {
+            cflist: Some(new_cf_list),
+        }
+    }
+
+    fn get_tx_dr_and_frequency(
+        &mut self,
+        random: u8,
+        datarate: DR,
+        frame: &Frame,
+    ) -> (Datarate, u32) {
+        (
+            DATARATES[datarate as usize].clone(),
+            match frame {
+                Frame::Data => {
+                    if let Some(cf_list) = self.cf_list {
+                        let channel = random as usize & 0b111;
+                        self.last_tx = channel;
+                        if channel < JOIN_CHANNELS.len() {
+                            JOIN_CHANNELS[channel][self.subband as usize]
+                        } else {
+                            cf_list[channel - JOIN_CHANNELS.len()]
+                        }
+                    } else {
+                        let channel = random as usize % JOIN_CHANNELS.len();
+                        self.last_tx = channel;
+                        JOIN_CHANNELS[channel][self.subband as usize]
+                    }
+                }
+                Frame::Join => {
+                    let channel = random as usize % JOIN_CHANNELS.len();
+                    self.last_tx = channel;
+                    JOIN_CHANNELS[channel][self.subband as usize]
+                }
+            },
+        )
+    }
+
+    fn get_rx_frequency(&self, _frame: &Frame, window: &Window) -> u32 {
+        match window {
+            Window::_1 => {
+                let channel = self.last_tx;
+                if let Some(cf_list) = self.cf_list {
+                    if channel < JOIN_CHANNELS.len() {
+                        JOIN_CHANNELS[channel][self.subband as usize]
+                    } else {
+                        cf_list[channel - JOIN_CHANNELS.len()]
+                    }
+                } else {
+                    JOIN_CHANNELS[channel][self.subband as usize]
+                }
+            }
+            Window::_2 => RX2_FREQUENCY[self.subband as usize],
+        }
+    }
+
+    fn get_dbm(&self) -> i8 {
+        AS_DBM
+    }
+
+    fn get_rx_datarate(&self, datarate: DR, _frame: &Frame, window: &Window) -> Datarate {
+        let datarate = match window {
+            Window::_1 => datarate,
+            Window::_2 => DR::_2,
+        };
+        DATARATES[datarate as usize].clone()
+    }
+}

--- a/device/src/region/in865/datarates.rs
+++ b/device/src/region/in865/datarates.rs
@@ -1,0 +1,29 @@
+use super::{Bandwidth, Datarate, SpreadingFactor};
+
+pub(crate) const DATARATES: [Datarate; 6] = [
+    Datarate {
+        spreading_factor: SpreadingFactor::_12,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_11,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_10,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_9,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_125KHz,
+    },
+    //ignore FSK data rate for now
+];

--- a/device/src/region/in865/mod.rs
+++ b/device/src/region/in865/mod.rs
@@ -1,0 +1,106 @@
+#![allow(dead_code)]
+use super::*;
+
+const JOIN_CHANNELS: [u32; 3] = [865_062_500, 865_402_500, 865_985_000];
+
+const IN_DBM: i8 = 30;
+
+mod datarates;
+use datarates::*;
+
+#[derive(Default)]
+#[allow(clippy::upper_case_acronyms)]
+pub struct IN865 {
+    subband: Option<u8>,
+    last_tx: usize,
+    cf_list: Option<[u32; 5]>,
+}
+
+impl IN865 {
+    pub fn new() -> IN865 {
+        Self::default()
+    }
+}
+
+use super::JoinAccept;
+
+impl RegionHandler for IN865 {
+    fn process_join_accept<T: core::convert::AsRef<[u8]>, C>(
+        &mut self,
+        join_accept: &super::DecryptedJoinAcceptPayload<T, C>,
+    ) -> JoinAccept {
+        let mut new_cf_list = [0, 0, 0, 0, 0];
+        if let Some(CfList::DynamicChannel(cf_list)) = join_accept.c_f_list() {
+            for (index, freq) in cf_list.iter().enumerate() {
+                new_cf_list[index] = freq.value();
+            }
+        }
+        self.cf_list = Some(new_cf_list);
+        JoinAccept {
+            cflist: Some(new_cf_list),
+        }
+    }
+
+    fn get_tx_dr_and_frequency(
+        &mut self,
+        random: u8,
+        datarate: DR,
+        frame: &Frame,
+    ) -> (Datarate, u32) {
+        (
+            DATARATES[datarate as usize].clone(),
+            match frame {
+                Frame::Data => {
+                    if let Some(cf_list) = self.cf_list {
+                        let channel = random as usize & 0b111;
+                        self.last_tx = channel;
+                        if channel < JOIN_CHANNELS.len() {
+                            JOIN_CHANNELS[channel]
+                        } else {
+                            cf_list[channel - JOIN_CHANNELS.len()]
+                        }
+                    } else {
+                        let channel = random as usize % JOIN_CHANNELS.len();
+                        self.last_tx = channel;
+                        JOIN_CHANNELS[channel]
+                    }
+                }
+                Frame::Join => {
+                    let channel = random as usize % JOIN_CHANNELS.len();
+                    self.last_tx = channel;
+                    JOIN_CHANNELS[channel]
+                }
+            },
+        )
+    }
+
+    fn get_rx_frequency(&self, _frame: &Frame, window: &Window) -> u32 {
+        match window {
+            Window::_1 => {
+                let channel = self.last_tx;
+                if let Some(cf_list) = self.cf_list {
+                    if channel < JOIN_CHANNELS.len() {
+                        JOIN_CHANNELS[channel]
+                    } else {
+                        cf_list[channel - JOIN_CHANNELS.len()]
+                    }
+                } else {
+                    JOIN_CHANNELS[channel]
+                }
+            }
+            Window::_2 => 866_550_000,
+        }
+    }
+
+    fn get_dbm(&self) -> i8 {
+        IN_DBM
+    }
+
+    fn get_rx_datarate(&self, datarate: DR, _frame: &Frame, window: &Window) -> Datarate {
+        let datarate = match window {
+            Window::_1 => datarate,
+            Window::_2 => DR::_2,
+        };
+        DATARATES[datarate as usize].clone()
+    }
+}

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -7,16 +7,20 @@ use crate::mac;
 pub(crate) use crate::radio::*;
 use constants::*;
 
+mod as923;
 mod au915;
 mod cn470;
 mod eu433;
 mod eu868;
+mod in865;
 mod us915;
 
+pub use as923::AS923;
 pub use au915::AU915;
 pub use cn470::CN470;
 pub use eu433::EU433;
 pub use eu868::EU868;
+pub use in865::IN865;
 pub use us915::US915;
 
 pub struct Configuration {
@@ -55,6 +59,11 @@ pub enum Region {
     EU868,
     EU433,
     AU915,
+    AS923_1,
+    AS923_2,
+    AS923_3,
+    AS923_4,
+    IN865,
 }
 
 enum State {
@@ -63,6 +72,8 @@ enum State {
     EU868(EU868),
     EU433(EU433),
     AU915(AU915),
+    AS923(AS923),
+    IN865(IN865),
 }
 
 impl State {
@@ -73,6 +84,11 @@ impl State {
             Region::EU868 => State::EU868(EU868::new()),
             Region::EU433 => State::EU433(EU433::new()),
             Region::AU915 => State::AU915(AU915::new()),
+            Region::AS923_1 => State::AS923(AS923::new(as923::AS923Subband::_1)),
+            Region::AS923_2 => State::AS923(AS923::new(as923::AS923Subband::_2)),
+            Region::AS923_3 => State::AS923(AS923::new(as923::AS923Subband::_3)),
+            Region::AS923_4 => State::AS923(AS923::new(as923::AS923Subband::_4)),
+            Region::IN865 => State::IN865(IN865::new()),
         }
     }
 }
@@ -102,6 +118,8 @@ macro_rules! mut_region_dispatch {
         State::EU868(state) => state.$t(),
         State::EU433(state) => state.$t(),
         State::AU915(state) => state.$t(),
+        State::AS923(state) => state.$t(),
+        State::IN865(state) => state.$t(),
     }
   };
   ($s:expr, $t:tt, $($arg:tt)*) => {
@@ -111,6 +129,8 @@ macro_rules! mut_region_dispatch {
         State::EU868(state) => state.$t($($arg)*),
         State::EU433(state) => state.$t($($arg)*),
         State::AU915(state) => state.$t($($arg)*),
+        State::AS923(state) => state.$t($($arg)*),
+        State::IN865(state) => state.$t($($arg)*),
     }
   };
 }
@@ -123,6 +143,8 @@ macro_rules! region_dispatch {
         State::EU868(state) => state.$t(),
         State::EU433(state) => state.$t(),
         State::AU915(state) => state.$t(),
+        State::AS923(state) => state.$t(),
+        State::IN865(state) => state.$t(),
     }
   };
   ($s:expr, $t:tt, $($arg:tt)*) => {
@@ -132,6 +154,8 @@ macro_rules! region_dispatch {
         State::EU868(state) => state.$t($($arg)*),
         State::EU433(state) => state.$t($($arg)*),
         State::AU915(state) => state.$t($($arg)*),
+        State::AS923(state) => state.$t($($arg)*),
+        State::IN865(state) => state.$t($($arg)*),
     }
   };
 }
@@ -263,6 +287,8 @@ from_region!(CN470);
 from_region!(EU868);
 from_region!(EU433);
 from_region!(AU915);
+from_region!(AS923);
+from_region!(IN865);
 
 use super::state_machines::JoinAccept;
 use lorawan::parser::DecryptedJoinAcceptPayload;


### PR DESCRIPTION
This is an implementation of AS923 (including subbands) and IN865 regions. 

For AS923_1, there is also AS923_1B. As I understand it, there is no difference on a device, only on gateways, but I'd appreciate a double check on that.