### PR TITLE
Allow SessionData to be extracted from Device

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -20,6 +20,7 @@ generic-array = "0.14.2"
 defmt = { version = "0.3.0", optional = true }
 futures = { version = "0.3.17", default-features = false, optional = true }
 rand_core = { version = "0.6.2", default-features = false, optional = true }
+serde = { version = "1.0.145", default-features = false, features = ["derive"]}
 
 [features]
 defmt = ["dep:defmt", "lorawan/defmt"]

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -20,9 +20,10 @@ generic-array = "0.14.2"
 defmt = { version = "0.3.0", optional = true }
 futures = { version = "0.3.17", default-features = false, optional = true }
 rand_core = { version = "0.6.2", default-features = false, optional = true }
-serde = { version = "1.0.145", default-features = false, features = ["derive"]}
+serde = { version = "1.0.145", default-features = false, features = ["derive"], optional = true}
 
 [features]
 defmt = ["dep:defmt", "lorawan/defmt"]
 default = []
 async = ["futures", "rand_core"]
+serde = ["dep:serde"]

--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -20,6 +20,7 @@ use lorawan::{
     parser::{parse_with_factory as lorawan_parse, *},
 };
 use rand_core::RngCore;
+use serde::{Deserialize, Serialize};
 
 type DevNonce = lorawan::parser::DevNonce<[u8; 2]>;
 use crate::radio::types::RadioBuffer;
@@ -71,10 +72,19 @@ where
     RNG: RngCore,
 {
     pub fn new(region: region::Configuration, radio: R, timer: T, rng: RNG) -> Self {
+        Self::new_with_session(region, radio, timer, rng, None)
+    }
+    pub fn new_with_session(
+        region: region::Configuration,
+        radio: R,
+        timer: T,
+        rng: RNG,
+        session: Option<SessionData>,
+    ) -> Self {
         Self {
             crypto: PhantomData::default(),
             radio,
-            session: None,
+            session,
             mac: Mac::default(),
             radio_buffer: RadioBuffer::new(),
             timer,
@@ -82,6 +92,10 @@ where
             datarate: region.get_default_datarate(),
             region,
         }
+    }
+
+    pub fn get_session(&mut self) -> Option<SessionData> {
+        self.session
     }
 
     /// Retrieve the current data rate being used by this device.
@@ -421,7 +435,8 @@ where
 }
 
 /// Contains data for the current session
-struct SessionData {
+#[derive(Copy, Clone, Serialize, Deserialize)]
+pub struct SessionData {
     newskey: AES128,
     appskey: AES128,
     devaddr: DevAddr<[u8; 4]>,

--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -374,7 +374,7 @@ where
 
             // Pass the full radio buffer slice to RX
             let rx_fut = self.radio.rx(rx_config, self.radio_buffer.as_raw_slice());
-            let timeout_fut = self.timer.delay_ms(window_duration.into());
+            let timeout_fut = self.timer.at(window_duration.into());
 
             pin_mut!(rx_fut);
             pin_mut!(timeout_fut);

--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -94,8 +94,8 @@ where
         }
     }
 
-    pub fn get_session(&mut self) -> Option<SessionData> {
-        self.session
+    pub fn get_session(&mut self) -> &Option<SessionData> {
+        &self.session
     }
 
     /// Retrieve the current data rate being used by this device.
@@ -435,7 +435,7 @@ where
 }
 
 /// Contains data for the current session
-#[derive(Copy, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct SessionData {
     newskey: AES128,
     appskey: AES128,

--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -20,7 +20,6 @@ use lorawan::{
     parser::{parse_with_factory as lorawan_parse, *},
 };
 use rand_core::RngCore;
-use serde::{Deserialize, Serialize};
 
 type DevNonce = lorawan::parser::DevNonce<[u8; 2]>;
 use crate::radio::types::RadioBuffer;
@@ -435,7 +434,8 @@ where
 }
 
 /// Contains data for the current session
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SessionData {
     newskey: AES128,
     appskey: AES128,

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -14,7 +14,7 @@ aes = { version = "0.6.0", optional = true }
 cmac = { version = "0.5.1", optional = true }
 generic-array = "0.14.4"
 defmt = { version = "0.3.0", optional = true }
-serde = { version = "1.0.145", default-features = false, features = ["derive"]}
+serde = { version = "1.0.145", default-features = false, features = ["derive"], optional = true}
 
 [dev-dependencies]
 criterion = "0.3"
@@ -26,11 +26,8 @@ harness = false
 
 [features]
 default = ["full"]
-
 full = ["with-to-string", "with-downlink", "default-crypto"]
-
 default-crypto = ["aes", "cmac"]
-
 with-to-string = []
-
 with-downlink = []
+serde = ["dep:serde"]

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -14,6 +14,7 @@ aes = { version = "0.6.0", optional = true }
 cmac = { version = "0.5.1", optional = true }
 generic-array = "0.14.4"
 defmt = { version = "0.3.0", optional = true }
+serde = { version = "1.0.145", default-features = false, features = ["derive"]}
 
 [dev-dependencies]
 criterion = "0.3"

--- a/encoding/src/keys.rs
+++ b/encoding/src/keys.rs
@@ -6,11 +6,11 @@
 //
 // author: Ivaylo Petrov <ivajloip@gmail.com>
 use super::securityhelpers::generic_array::{typenum::U16, GenericArray};
-use serde::{Deserialize, Serialize};
 
 /// AES128 represents 128 bit AES key.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub struct AES128(pub [u8; 16]);
 
 impl From<[u8; 16]> for AES128 {

--- a/encoding/src/keys.rs
+++ b/encoding/src/keys.rs
@@ -6,10 +6,11 @@
 //
 // author: Ivaylo Petrov <ivajloip@gmail.com>
 use super::securityhelpers::generic_array::{typenum::U16, GenericArray};
+use serde::{Deserialize, Serialize};
 
 /// AES128 represents 128 bit AES key.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub struct AES128(pub [u8; 16]);
 
 impl From<[u8; 16]> for AES128 {

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -44,6 +44,7 @@ macro_rules! fixed_len_struct {
         struct $type:ident[$size:expr];
     ) => {
         $(#[$outer])*
+        #[derive(Debug, Eq)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub struct $type<T: AsRef<[u8]>>(T);
 

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -34,7 +34,6 @@ use super::maccommands::{
 };
 use super::securityhelpers;
 use super::securityhelpers::generic_array::GenericArray;
-use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "default-crypto")]
 use super::default_crypto::DefaultFactory;
@@ -45,7 +44,7 @@ macro_rules! fixed_len_struct {
         struct $type:ident[$size:expr];
     ) => {
         $(#[$outer])*
-        #[derive(Debug, Eq, Serialize, Deserialize)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub struct $type<T: AsRef<[u8]>>(T);
 
         impl<T: AsRef<[u8]>> $type<T> {

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -34,6 +34,7 @@ use super::maccommands::{
 };
 use super::securityhelpers;
 use super::securityhelpers::generic_array::GenericArray;
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "default-crypto")]
 use super::default_crypto::DefaultFactory;
@@ -44,7 +45,7 @@ macro_rules! fixed_len_struct {
         struct $type:ident[$size:expr];
     ) => {
         $(#[$outer])*
-        #[derive(Debug, Eq)]
+        #[derive(Debug, Eq, Serialize, Deserialize)]
         pub struct $type<T: AsRef<[u8]>>(T);
 
         impl<T: AsRef<[u8]>> $type<T> {


### PR DESCRIPTION
Right now there is no way to persist the SessionData to flash. This is a requirement for LoraWan 1.0.4 but is also nice to have just for being able to delete the Device for saving power in sleep.