### PR TITLE
Parameterize error using PhyRxTx::PhyError

### DIFF
--- a/device/src/async_device/radio.rs
+++ b/device/src/async_device/radio.rs
@@ -2,12 +2,9 @@ pub use crate::radio::{types::*, RfConfig, RxQuality, TxConfig};
 use core::future::Future;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Error<R: PhyRxTx>(pub R::PhyError);
+pub struct Error<E>(pub E);
 
-impl<R> From<Error<R>> for super::Error<R>
-where
-    R: PhyRxTx,
-{
+impl<R> From<Error<R>> for super::Error<R> {
     fn from(radio_error: Error<R>) -> super::Error<R> {
         super::Error::Radio(radio_error.0)
     }

--- a/device/src/radio/mod.rs
+++ b/device/src/radio/mod.rs
@@ -28,17 +28,14 @@ where
 }
 
 #[derive(Debug)]
-pub enum Error<R>
-where
-    R: PhyRxTx,
-{
+pub enum Error<R> {
     TxRequestDuringTx,
     TxRequestDuringRx,
     RxRequestDuringTx,
     RxRequestDuringRx,
     CancelRxWhileIdle,
     CancelRxDuringTx,
-    PhyError(R::PhyError),
+    PhyError(R),
 }
 
 use core::fmt;
@@ -52,7 +49,7 @@ pub trait PhyRxTx {
 
     // we require mutability so we may decrypt in place
     fn get_received_packet(&mut self) -> &mut [u8];
-    fn handle_event(&mut self, event: Event<Self>) -> Result<Response<Self>, Error<Self>>
+    fn handle_event(&mut self, event: Event<Self>) -> Result<Response<Self>, Error<Self::PhyError>>
     where
         Self: core::marker::Sized;
 }

--- a/device/src/state_machines/no_session.rs
+++ b/device/src/state_machines/no_session.rs
@@ -64,7 +64,10 @@ impl NoSession {
         self,
         event: Event<R>,
         shared: &mut Shared<R, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
+    ) -> (
+        SuperState,
+        Result<Response, super::super::Error<R::PhyError>>,
+    ) {
         match self {
             NoSession::Idle(state) => state.handle_event::<R, C, N>(event, shared),
             NoSession::SendingJoin(state) => state.handle_event::<R, C, N>(event, shared),
@@ -87,10 +90,7 @@ pub enum Error {
     NewSessionWhileWaitingForJoinResponse,
 }
 
-impl<R> From<Error> for super::super::Error<R>
-where
-    R: radio::PhyRxTx,
-{
+impl<R> From<Error> for super::super::Error<R> {
     fn from(error: Error) -> super::super::Error<R> {
         super::super::Error::NoSession(error)
     }
@@ -105,7 +105,10 @@ impl Idle {
         self,
         event: Event<R>,
         shared: &mut Shared<R, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
+    ) -> (
+        SuperState,
+        Result<Response, super::super::Error<R::PhyError>>,
+    ) {
         match event {
             // NewSession Request or a Timeout from previously failed Join attempt
             Event::NewSessionRequest | Event::TimeoutFired => {
@@ -192,7 +195,10 @@ impl SendingJoin {
         self,
         event: Event<R>,
         shared: &mut Shared<R, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
+    ) -> (
+        SuperState,
+        Result<Response, super::super::Error<R::PhyError>>,
+    ) {
         match event {
             // we are waiting for the async tx to complete
             Event::RadioEvent(radio_event) => {
@@ -251,7 +257,10 @@ impl WaitingForRxWindow {
         self,
         event: Event<R>,
         shared: &mut Shared<R, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
+    ) -> (
+        SuperState,
+        Result<Response, super::super::Error<R::PhyError>>,
+    ) {
         match event {
             // we are waiting for a Timeout
             Event::TimeoutFired => {
@@ -327,7 +336,10 @@ impl WaitingForJoinResponse {
         self,
         event: Event<R>,
         shared: &mut Shared<R, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
+    ) -> (
+        SuperState,
+        Result<Response, super::super::Error<R::PhyError>>,
+    ) {
         match event {
             // we are waiting for the async tx to complete
             Event::RadioEvent(radio_event) => {

--- a/device/src/state_machines/session.rs
+++ b/device/src/state_machines/session.rs
@@ -105,10 +105,7 @@ pub enum Error {
     SendDataWhileWaitingForRx,
 }
 
-impl<R> From<Error> for super::super::Error<R>
-where
-    R: radio::PhyRxTx,
-{
+impl<R> From<Error> for super::super::Error<R> {
     fn from(error: Error) -> super::super::Error<R> {
         super::super::Error::Session(error)
     }
@@ -132,7 +129,10 @@ impl Session {
         self,
         event: Event<R>,
         shared: &mut Shared<R, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
+    ) -> (
+        SuperState,
+        Result<Response, super::super::Error<R::PhyError>>,
+    ) {
         match self {
             Session::Idle(state) => state.handle_event::<R, C, N>(event, shared),
             Session::SendingData(state) => state.handle_event::<R, C, N>(event, shared),
@@ -192,7 +192,10 @@ impl Idle {
         mut self,
         event: Event<R>,
         shared: &mut Shared<R, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
+    ) -> (
+        SuperState,
+        Result<Response, super::super::Error<R::PhyError>>,
+    ) {
         match event {
             Event::SendDataRequest(send_data) => {
                 // encodes the packet and places it in send buffer
@@ -276,7 +279,10 @@ impl SendingData {
         self,
         event: Event<R>,
         shared: &mut Shared<R, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
+    ) -> (
+        SuperState,
+        Result<Response, super::super::Error<R::PhyError>>,
+    ) {
         match event {
             // we are waiting for the async tx to complete
             Event::RadioEvent(radio_event) => {
@@ -332,7 +338,10 @@ impl WaitingForRxWindow {
         self,
         event: Event<R>,
         shared: &mut Shared<R, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
+    ) -> (
+        SuperState,
+        Result<Response, super::super::Error<R::PhyError>>,
+    ) {
         match event {
             // we are waiting for a Timeout
             Event::TimeoutFired => {
@@ -410,7 +419,10 @@ impl WaitingForRx {
         mut self,
         event: Event<R>,
         shared: &mut Shared<R, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R>>) {
+    ) -> (
+        SuperState,
+        Result<Response, super::super::Error<R::PhyError>>,
+    ) {
         match event {
             // we are waiting for the async tx to complete
             Event::RadioEvent(radio_event) => {
@@ -563,7 +575,10 @@ fn data_rxwindow1_timeout<
     confirmed: bool,
     timestamp_ms: TimestampMs,
     shared: &mut Shared<R, N>,
-) -> (SuperState, Result<Response, super::super::Error<R>>) {
+) -> (
+    SuperState,
+    Result<Response, super::super::Error<R::PhyError>>,
+) {
     let (new_state, first_window) = match state {
         Session::Idle(state) => {
             let first_window = (shared.region.get_rx_delay(&Frame::Data, &Window::_1) as i32


### PR DESCRIPTION
Parameterizing the error type by PhyRxTx::PhyError removes the requirement to implement Debug/defmt::Format for the PhyRxTx type, and allows implementing that only for the PhyRxTx::PhyError type. This makes it a lot more convenient to log errors.