### PR TITLE
make ChannelMask type with a generic const parameter

### DIFF
--- a/device/src/region/au915/mod.rs
+++ b/device/src/region/au915/mod.rs
@@ -39,7 +39,7 @@ impl RegionHandler for AU915 {
         JoinAccept { cflist: None }
     }
 
-    fn set_channel_mask(&mut self, _chmask: ChannelMask) {
+    fn set_channel_mask<const N: usize>(&mut self, _chmask: ChannelMask<N>) {
         // one day this should truly be handled
     }
 

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -213,7 +213,7 @@ impl Configuration {
         mut_region_dispatch!(self, process_join_accept, join_accept)
     }
 
-    pub(crate) fn set_channel_mask(&mut self, channel_mask: ChannelMask) {
+    pub(crate) fn set_channel_mask<const N: usize>(&mut self, channel_mask: ChannelMask<N>) {
         mut_region_dispatch!(self, set_channel_mask, channel_mask)
     }
 
@@ -275,7 +275,7 @@ pub(crate) trait RegionHandler {
         &mut self,
         join_accept: &DecryptedJoinAcceptPayload<T, C>,
     ) -> JoinAccept;
-    fn set_channel_mask(&mut self, _channel_mask: ChannelMask) {
+    fn set_channel_mask<const N: usize>(&mut self, _channel_mask: ChannelMask<N>) {
         // does not apply to every region
     }
     fn set_subband(&mut self, _subband: u8) {

--- a/device/src/region/us915/mod.rs
+++ b/device/src/region/us915/mod.rs
@@ -40,7 +40,7 @@ impl RegionHandler for US915 {
         JoinAccept { cflist: None }
     }
 
-    fn set_channel_mask(&mut self, _chmask: ChannelMask) {
+    fn set_channel_mask<const N: usize>(&mut self, _chmask: ChannelMask<N>) {
         // one day this should truly be handled
     }
 

--- a/encoding/src/maccommandcreator.rs
+++ b/encoding/src/maccommandcreator.rs
@@ -188,7 +188,7 @@ impl LinkADRReqCreator {
     ///
     /// * channel_mask - instance of maccommands::ChannelMask or anything that can be converted
     /// into it.
-    pub fn set_channel_mask<T: Into<ChannelMask>>(&mut self, channel_mask: T) -> &mut Self {
+    pub fn set_channel_mask<T: Into<ChannelMask<2>>>(&mut self, channel_mask: T) -> &mut Self {
         let converted = channel_mask.into();
         self.data[2] = converted.as_ref()[0];
         self.data[3] = converted.as_ref()[1];

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -467,7 +467,7 @@ impl<T: AsRef<[u8]>, F: CryptoFactory> DecryptedJoinAcceptPayload<T, F> {
 #[derive(Debug, PartialEq, Eq)]
 pub enum CfList<'a> {
     DynamicChannel([Frequency<'a>; 5]),
-    FixedChannel([ChannelMask; 4]),
+    FixedChannel(ChannelMask<9>),
 }
 
 impl<T: AsRef<[u8]>, F> DecryptedJoinAcceptPayload<T, F> {
@@ -515,15 +515,7 @@ impl<T: AsRef<[u8]>, F> DecryptedJoinAcceptPayload<T, F> {
             ];
             Some(CfList::DynamicChannel(res))
         } else if c_f_list_type == 1 {
-            let res = [
-                ChannelMask::new_from_raw(&d[13..15]),
-                ChannelMask::new_from_raw(&d[15..17]),
-                ChannelMask::new_from_raw(&d[17..19]),
-                ChannelMask::new_from_raw(&d[19..21]),
-                // 21..22 RFU
-                // 22..25 RFU
-            ];
-            Some(CfList::FixedChannel(res))
+            Some(CfList::FixedChannel(ChannelMask::new_from_raw(&d[13..22])))
         } else {
             None
         }

--- a/encoding/tests/maccommands.rs
+++ b/encoding/tests/maccommands.rs
@@ -288,9 +288,9 @@ fn test_channel_mask() {
     expected[0] = true;
     expected[1] = true;
     expected[12] = true;
-    let chan_mask = ChannelMask::new(&data[..]);
+    let chan_mask = ChannelMask::<2>::new(&data[..]);
     assert!(chan_mask.is_ok());
-    assert_eq!(&chan_mask.unwrap().statuses()[..], &expected[..]);
+    assert_eq!(&chan_mask.unwrap().statuses::<16>()[..], &expected[..]);
 }
 
 #[test]


### PR DESCRIPTION
Using the recent const generic feature, we can make the ChannelMask type more generally useful. This makes the type work well when receiving ChannelMask in CFList from the JoinAccept in US915 and AU915; that is to say, asking the type if a specific channel is enabled works (but no effort in this PR is made for storing it and using it in the region handlers).

Note that #91 raises the issue of ChMaskCntl which this does not address. More work is needed for Fixed Channel Plans (US915 and AU915) should they leverage the ChannelMask in LinkADRReq; they currently do not.