### PR TITLE
Fix RX1 channel calculation for fixed frequency plans

### DIFF
--- a/device/src/region/fixed_channel_plans/mod.rs
+++ b/device/src/region/fixed_channel_plans/mod.rs
@@ -143,7 +143,7 @@ impl<const D: usize, F: FixedChannelRegion<D>> RegionHandler for FixedChannelPla
     }
 
     fn get_rx_frequency(&self, _frame: &Frame, window: &Window) -> u32 {
-        let channel = self.last_tx_channel % 7;
+        let channel = self.last_tx_channel % 8;
         match window {
             Window::_1 => F::downlink_channels()[channel as usize],
             Window::_2 => F::get_default_rx2(),


### PR DESCRIPTION
There seems to be a bug in the RX1 channel calculation. According to the regional parameters document, the downlink channel for the RX1 window should be `(uplink channel % 8)`.

![Screenshot_20230317_173651](https://user-images.githubusercontent.com/8854139/226057894-1bce3bad-ca76-4b97-8ac6-52fab96a5da6.png)
![Screenshot_20230317_173633](https://user-images.githubusercontent.com/8854139/226057897-4a2d3998-279e-42bb-8efd-1817aa989386.png)
