### PR TITLE
Increment FCntUp on every transmission

### DIFF
--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -221,6 +221,13 @@ where
             .region
             .create_tx_config(&mut self.rng, self.datarate, &Frame::Data);
 
+        // Unless the same frame is to be retransmitted (see NbTrans parameter of LinkADRReq command, LoRaWAN spec
+        // 1.0.2 section 5.2 for retransmissions), FCnt must be incremented on each transmission.
+        self.session
+            .as_mut()
+            .ok_or(Error::NetworkNotJoined)?
+            .fcnt_up_increment();
+
         // Transmit our data packet
         let ms = self
             .radio


### PR DESCRIPTION
According to the LoRaWAN spec (section 4.3.1.5), FCntUp should be incremented for every new transmission (expect in cases where the same frame should be retransmitted). To my understanding, the FCntUp and FCntDown counters are totally independent, ie, FCntUp doesn't need to be incremented upon a successfuly received downlink message ([here](https://github.com/ivajloip/rust-lorawan/blob/6d0eb5509edc9ce7a07f5e8423f63afb45b29f70/device/src/async_device/mod.rs#L253)), although I don't think it actually hurts to increment nonetheless in that case.

During some of my testing, The Things Stack would stop accepting uplinks because FCnt would always remain constant frame to frame. With this fix, now all my messages are accepted and forwarded to the application.

![Screenshot_20230317_182136](https://user-images.githubusercontent.com/8854139/226063141-f5369ed1-d18c-487b-a973-151761cee8c0.png)
