### PR TITLE
Add 1.0.4 commands to encoding

### DIFF
--- a/encoding/src/maccommandcreator.rs
+++ b/encoding/src/maccommandcreator.rs
@@ -613,19 +613,19 @@ impl_mac_cmd_creator_boilerplate!(TXParamSetupReqCreator, 0x09, 2);
 impl TXParamSetupReqCreator {
     pub fn set_downlink_dwell_time(&mut self) -> &mut Self {
         self.data[1] &= 0xfe;
-        self.data[1] |= (1 << 4) as u8;
+        self.data[1] |= (1 << 5) as u8;
         self
     }
     pub fn set_uplink_dwell_time(&mut self) -> &mut Self {
         self.data[1] &= 0xfe;
-        self.data[1] |= (1 << 3) as u8;
+        self.data[1] |= (1 << 4) as u8;
         self
     }
     pub fn set_max_eirp(&mut self, max_eirp: u8) -> Result<&mut Self, &str> {
-        if max_eirp > 0x07 {
+        if max_eirp > 0x0F {
             return Err("max_eirp out of range");
         }
-        self.data[1] &= 0xf8;
+        self.data[1] &= 0xf0;
         self.data[1] |= max_eirp;
 
         Ok(self)

--- a/encoding/src/maccommandcreator.rs
+++ b/encoding/src/maccommandcreator.rs
@@ -604,6 +604,112 @@ pub struct RXTimingSetupAnsCreator {}
 
 impl_mac_cmd_creator_boilerplate!(RXTimingSetupAnsCreator, 0x08);
 
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TXParamSetupReqCreator {
+    data: [u8; 2],
+}
+impl_mac_cmd_creator_boilerplate!(TXParamSetupReqCreator, 0x09, 2);
+impl TXParamSetupReqCreator {
+    pub fn set_downlink_dwell_time(&mut self) -> &mut Self {
+        self.data[1] &= 0xfe;
+        self.data[1] |= (1 << 4) as u8;
+        self
+    }
+    pub fn set_uplink_dwell_time(&mut self) -> &mut Self {
+        self.data[1] &= 0xfe;
+        self.data[1] |= (1 << 3) as u8;
+        self
+    }
+    pub fn set_max_eirp(&mut self, max_eirp: u8) -> Result<&mut Self, &str> {
+        if max_eirp > 0x07 {
+            return Err("max_eirp out of range");
+        }
+        self.data[1] &= 0xf8;
+        self.data[1] |= max_eirp;
+
+        Ok(self)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TXParamSetupAnsCreator;
+impl_mac_cmd_creator_boilerplate!(TXParamSetupAnsCreator, 0x09);
+
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DlChannelReqCreator {
+    data: [u8; 5],
+}
+impl_mac_cmd_creator_boilerplate!(DlChannelReqCreator, 0x0A, 5);
+impl DlChannelReqCreator {
+    pub fn set_channel_index(&mut self, index: u8) -> &mut Self {
+        self.data[1] = index;
+        self
+    }
+    pub fn set_frequency<'a, T: Into<Frequency<'a>>>(&mut self, frequency: T) -> &mut Self {
+        let converted = frequency.into();
+        self.data[2..5].copy_from_slice(converted.as_ref());
+
+        self
+    }
+}
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DlChannelAnsCreator {
+    data: [u8; 2],
+}
+impl_mac_cmd_creator_boilerplate!(DlChannelAnsCreator, 0x0A, 2);
+impl DlChannelAnsCreator {
+    /// Sets the channel frequency acknowledgement of the DlChannelAns to the provided value.
+    ///
+    /// # Argument
+    ///
+    /// * ack - true meaning that the channel frequency was acceptable or false otherwise.
+    pub fn set_channel_frequency_ack(&mut self, ack: bool) -> &mut Self {
+        self.data[1] &= 0xfe;
+        self.data[1] |= ack as u8;
+
+        self
+    }
+
+    /// Sets the uplink frequency exists acknowledgement of the DlChannelAns to the provided value.
+    ///
+    /// # Argument
+    ///
+    /// * ack - true meaning that the data rate range was acceptable or false otherwise.
+    pub fn set_uplink_frequency_exists_ack(&mut self, ack: bool) -> &mut Self {
+        self.data[1] &= 0xfd;
+        self.data[1] |= (ack as u8) << 1;
+
+        self
+    }
+}
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DeviceTimeReqCreator;
+impl_mac_cmd_creator_boilerplate!(DeviceTimeReqCreator, 0x0D);
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct DeviceTimeAnsCreator {
+    data: [u8; 6],
+}
+impl_mac_cmd_creator_boilerplate!(DeviceTimeAnsCreator, 0x0D, 6);
+impl DeviceTimeAnsCreator {
+    pub fn set_seconds(&mut self, seconds: u32) -> &mut Self {
+        self.data[1..5].copy_from_slice(&seconds.to_le_bytes());
+        self
+    }
+    pub fn set_nano_seconds(&mut self, nano_seconds: u32) -> Result<&mut Self, &str> {
+        if nano_seconds > 1000000000 {
+            return Err("nano_seconds out of range (max 1 second)");
+        }
+        self.data[5] = (nano_seconds / 3906250) as u8;
+        Ok(self)
+    }
+}
+
 pub fn build_mac_commands<'a, T: AsMut<[u8]>>(
     cmds: &[&dyn SerializableMacCommand],
     mut out: T,

--- a/encoding/src/maccommands.rs
+++ b/encoding/src/maccommands.rs
@@ -333,7 +333,7 @@ mac_cmds! {
     /// DeviceTimeAnsPayload represents the DeviceTimeAns LoRaWAN MACCommand.
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq, Eq)]
-    struct DeviceTimeAnsPayload[cmd=DeviceTimeAns, cid=0x0D, uplink=false, size=8]
+    struct DeviceTimeAnsPayload[cmd=DeviceTimeAns, cid=0x0D, uplink=false, size=5]
 }
 
 macro_rules! create_ack_fn {
@@ -870,10 +870,10 @@ impl<'a> TXParamSetupReqPayload<'a> {
         self.0[0] & (1 << 4) != 0
     }
     pub fn uplink_dwell_time(&self) -> bool {
-        self.0[0] & (1 << 4) != 0
+        self.0[0] & (1 << 3) != 0
     }
     pub fn max_eirp(&self) -> u8 {
-        match self.0[0] & (0b111) {
+        match self.0[0] & (0b1111) {
             0 => 8,
             1 => 10,
             2 => 12,
@@ -929,7 +929,7 @@ impl DlChannelAnsPayload<'_> {
 
 impl DeviceTimeAnsPayload<'_> {
     pub fn seconds(&self) -> u32 {
-        u32::from_le_bytes([self.0[0], self.0[1], self.0[2], self.0[3]])
+        u32::from_le_bytes([self.0[3], self.0[2], self.0[1], self.0[0]])
     }
     //raw value in 1/256 seconds
     pub fn nano_seconds(&self) -> u32 {

--- a/encoding/src/maccommands.rs
+++ b/encoding/src/maccommands.rs
@@ -867,10 +867,10 @@ impl<'a> RXTimingSetupReqPayload<'a> {
 
 impl<'a> TXParamSetupReqPayload<'a> {
     pub fn downlink_dwell_time(&self) -> bool {
-        self.0[0] & (1 << 4) != 0
+        self.0[0] & (1 << 5) != 0
     }
     pub fn uplink_dwell_time(&self) -> bool {
-        self.0[0] & (1 << 3) != 0
+        self.0[0] & (1 << 4) != 0
     }
     pub fn max_eirp(&self) -> u8 {
         match self.0[0] & (0b1111) {
@@ -923,7 +923,7 @@ impl DlChannelAnsPayload<'_> {
 
     /// Whether the device has accepted the new downlink frequency.
     pub fn ack(&self) -> bool {
-        self.0[0] == 0x01
+        self.0[0] & 0x03 == 0x03
     }
 }
 

--- a/encoding/src/maccommands.rs
+++ b/encoding/src/maccommands.rs
@@ -24,6 +24,12 @@ pub enum MacCommand<'a> {
     NewChannelAns(NewChannelAnsPayload<'a>),
     RXTimingSetupReq(RXTimingSetupReqPayload<'a>),
     RXTimingSetupAns(RXTimingSetupAnsPayload),
+    TXParamSetupReq(TXParamSetupReqPayload<'a>),
+    TXParamSetupAns(TXParamSetupAnsPayload),
+    DeviceTimeReq(DeviceTimeReqPayload),
+    DeviceTimeAns(DeviceTimeAnsPayload<'a>),
+    DlChannelReq(DlChannelReqPayload<'a>),
+    DlChannelAns(DlChannelAnsPayload<'a>),
 }
 
 impl<'a> MacCommand<'a> {
@@ -44,6 +50,12 @@ impl<'a> MacCommand<'a> {
             MacCommand::NewChannelAns(_) => NewChannelAnsPayload::len(),
             MacCommand::RXTimingSetupReq(_) => RXTimingSetupReqPayload::len(),
             MacCommand::RXTimingSetupAns(_) => RXTimingSetupAnsPayload::len(),
+            MacCommand::TXParamSetupReq(_) => TXParamSetupReqPayload::len(),
+            MacCommand::TXParamSetupAns(_) => TXParamSetupAnsPayload::len(),
+            MacCommand::DeviceTimeReq(_) => DeviceTimeReqPayload::len(),
+            MacCommand::DeviceTimeAns(_) => DeviceTimeAnsPayload::len(),
+            MacCommand::DlChannelReq(_) => DlChannelReqPayload::len(),
+            MacCommand::DlChannelAns(_) => DlChannelAnsPayload::len(),
         }
     }
 
@@ -63,6 +75,12 @@ impl<'a> MacCommand<'a> {
             MacCommand::NewChannelAns(ref v) => v.0,
             MacCommand::RXTimingSetupReq(ref v) => v.0,
             MacCommand::RXTimingSetupAns(_) => &[],
+            MacCommand::TXParamSetupReq(ref v) => v.0,
+            MacCommand::TXParamSetupAns(_) => &[],
+            MacCommand::DeviceTimeReq(_) => &[],
+            MacCommand::DeviceTimeAns(ref v) => v.0,
+            MacCommand::DlChannelReq(ref v) => v.0,
+            MacCommand::DlChannelAns(ref v) => v.0,
         }
     }
 }
@@ -94,6 +112,12 @@ impl<'a> SerializableMacCommand for MacCommand<'a> {
             MacCommand::NewChannelAns(_) => NewChannelAnsPayload::cid(),
             MacCommand::RXTimingSetupReq(_) => RXTimingSetupReqPayload::cid(),
             MacCommand::RXTimingSetupAns(_) => RXTimingSetupAnsPayload::cid(),
+            MacCommand::TXParamSetupReq(_) => TXParamSetupReqPayload::cid(),
+            MacCommand::TXParamSetupAns(_) => TXParamSetupAnsPayload::cid(),
+            MacCommand::DeviceTimeReq(_) => DeviceTimeReqPayload::cid(),
+            MacCommand::DeviceTimeAns(_) => DeviceTimeAnsPayload::cid(),
+            MacCommand::DlChannelReq(_) => DlChannelReqPayload::cid(),
+            MacCommand::DlChannelAns(_) => DlChannelAnsPayload::cid(),
         }
     }
 
@@ -227,6 +251,17 @@ mac_cmd_zero_len! {
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq, Eq)]
     struct RXTimingSetupAnsPayload[cmd=RXTimingSetupAns, cid=0x08, uplink=true]
+
+    /// TXParamSetupAnsPayload represents the TXParamSetupAns LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[derive(Debug, PartialEq, Eq)]
+    struct TXParamSetupAnsPayload[cmd=TXParamSetupAns, cid=0x09, uplink=true]
+
+    /// DeviceTimeReqPayload represents the DeviceTimeReq LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[derive(Debug, PartialEq, Eq)]
+    struct DeviceTimeReqPayload[cmd=DeviceTimeReq, cid=0x0D, uplink=true]
+
 }
 
 mac_cmds! {
@@ -279,6 +314,26 @@ mac_cmds! {
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[derive(Debug, PartialEq, Eq)]
     struct RXTimingSetupReqPayload[cmd=RXTimingSetupReq, cid=0x08, uplink=false, size=1]
+
+    /// TXParamSetupReqPayload represents the TXParamSetupReq LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[derive(Debug, PartialEq, Eq)]
+    struct TXParamSetupReqPayload[cmd=TXParamSetupReq, cid=0x09, uplink=false, size=1]
+
+    /// DlChannelReqPayload represents the DlChannelReq LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[derive(Debug, PartialEq, Eq)]
+    struct DlChannelReqPayload[cmd=DlChannelReq, cid=0x0A, uplink=false, size=4]
+
+    /// DlChannelAnsPayload represents the DlChannelAns LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[derive(Debug, PartialEq, Eq)]
+    struct DlChannelAnsPayload[cmd=DlChannelAns, cid=0x0A, uplink=true, size=1]
+
+    /// DeviceTimeAnsPayload represents the DeviceTimeAns LoRaWAN MACCommand.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[derive(Debug, PartialEq, Eq)]
+    struct DeviceTimeAnsPayload[cmd=DeviceTimeAns, cid=0x0D, uplink=false, size=8]
 }
 
 macro_rules! create_ack_fn {
@@ -807,5 +862,77 @@ impl<'a> RXTimingSetupReqPayload<'a> {
     /// Delay before the first RX window.
     pub fn delay(&self) -> u8 {
         self.0[0] & 0x0f
+    }
+}
+
+impl<'a> TXParamSetupReqPayload<'a> {
+    pub fn downlink_dwell_time(&self) -> bool {
+        self.0[0] & (1 << 4) != 0
+    }
+    pub fn uplink_dwell_time(&self) -> bool {
+        self.0[0] & (1 << 4) != 0
+    }
+    pub fn max_eirp(&self) -> u8 {
+        match self.0[0] & (0b111) {
+            0 => 8,
+            1 => 10,
+            2 => 12,
+            3 => 13,
+            4 => 14,
+            5 => 16,
+            6 => 18,
+            7 => 20,
+            8 => 21,
+            9 => 24,
+            10 => 26,
+            11 => 27,
+            12 => 29,
+            13 => 30,
+            14 => 33,
+            15 => 36,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl DlChannelReqPayload<'_> {
+    create_value_reader_fn!(
+        /// The index of the channel being created or modified.
+        channel_index,
+        0
+    );
+
+    /// The frequency of the new or modified channel.
+    pub fn frequency(&self) -> Frequency {
+        Frequency::new_from_raw(&self.0[1..4])
+    }
+}
+
+impl DlChannelAnsPayload<'_> {
+    create_ack_fn!(
+        /// Channel frequency ok
+        channel_freq_ack,
+        0
+    );
+
+    create_ack_fn!(
+        /// Uplink frequency exists
+        uplink_freq_ack,
+        1
+    );
+
+    /// Whether the device has accepted the new downlink frequency.
+    pub fn ack(&self) -> bool {
+        self.0[0] == 0x01
+    }
+}
+
+impl DeviceTimeAnsPayload<'_> {
+    pub fn seconds(&self) -> u32 {
+        u32::from_le_bytes([self.0[0], self.0[1], self.0[2], self.0[3]])
+    }
+    //raw value in 1/256 seconds
+    pub fn nano_seconds(&self) -> u32 {
+        (self.0[4] as u32) * 3906250
     }
 }

--- a/encoding/tests/maccommandcreator.rs
+++ b/encoding/tests/maccommandcreator.rs
@@ -172,13 +172,13 @@ fn test_tx_param_setup_req_creator() {
     creator.set_uplink_dwell_time().set_uplink_dwell_time();
     creator.set_max_eirp(3);
     let res = creator.build();
-    assert_eq!(res, [TXParamSetupReqPayload::cid(), 0x1B]);
+    assert_eq!(res, [TXParamSetupReqPayload::cid(), 0b110011]);
 }
 
 #[test]
 fn test_tx_param_setup_req_creator_bad_max_eirp() {
     let mut creator = TXParamSetupReqCreator::new();
-    assert!(creator.set_max_eirp(8).is_err());
+    assert!(creator.set_max_eirp(17).is_err());
 }
 
 #[test]

--- a/encoding/tests/maccommandcreator.rs
+++ b/encoding/tests/maccommandcreator.rs
@@ -152,7 +152,11 @@ fn test_rx_timing_setup_req_creator() {
     let res = creator.set_delay(0x0f).unwrap().build();
     assert_eq!(res, [RXTimingSetupReqPayload::cid(), 0x0f]);
 }
-
+#[test]
+fn test_rx_timing_setup_ans_creator() {
+    let creator = RXTimingSetupAnsCreator::new();
+    assert_eq!(creator.build(), [RXTimingSetupAnsPayload::cid()]);
+}
 #[test]
 fn test_rx_timing_setup_req_creator_bad_delay() {
     let mut creator = RXTimingSetupReqCreator::new();

--- a/encoding/tests/maccommandcreator.rs
+++ b/encoding/tests/maccommandcreator.rs
@@ -160,10 +160,40 @@ fn test_rx_timing_setup_req_creator_bad_delay() {
 }
 
 #[test]
-fn test_rx_timing_setup_ans_creator() {
-    let creator = RXTimingSetupAnsCreator::new();
+fn test_tx_param_setup_req_creator() {
+    let mut creator = TXParamSetupReqCreator::new();
+    creator.set_downlink_dwell_time();
+    creator.set_uplink_dwell_time().set_uplink_dwell_time();
+    creator.set_max_eirp(3);
     let res = creator.build();
-    assert_eq!(res, [RXTimingSetupAnsPayload::cid()]);
+    assert_eq!(res, [TXParamSetupReqPayload::cid(), 0x1B]);
+}
+#[test]
+fn test_tx_param_setup_req_creator_bad_max_eirp() {
+    let mut creator = TXParamSetupReqCreator::new();
+    assert!(creator.set_max_eirp(8).is_err());
+}
+#[test]
+fn test_dl_channel_req_creator() {
+    let mut creator = DlChannelReqCreator::new();
+    creator.set_channel_index(3);
+    creator.set_frequency(&[0x12, 0x34, 0x56]);
+    let res = creator.build();
+    assert_eq!(res, [DlChannelReqPayload::cid(), 0x03, 0x12, 0x34, 0x56]);
+}
+#[test]
+fn test_device_time_req_creator() {
+    let creator = DeviceTimeReqCreator::new();
+    let res = creator.build();
+    assert_eq!(res, [DeviceTimeReqPayload::cid()]);
+}
+#[test]
+fn test_device_time_ans_creator() {
+    let mut creator = DeviceTimeAnsCreator::new();
+    creator.set_seconds(123456);
+    creator.set_nano_seconds(123456789);
+    let res = creator.build();
+    assert_eq!(res, [DeviceTimeAnsPayload::cid(), 64, 226, 1, 0, 31]);
 }
 
 #[test]

--- a/encoding/tests/maccommandcreator.rs
+++ b/encoding/tests/maccommandcreator.rs
@@ -152,11 +152,13 @@ fn test_rx_timing_setup_req_creator() {
     let res = creator.set_delay(0x0f).unwrap().build();
     assert_eq!(res, [RXTimingSetupReqPayload::cid(), 0x0f]);
 }
+
 #[test]
 fn test_rx_timing_setup_ans_creator() {
     let creator = RXTimingSetupAnsCreator::new();
     assert_eq!(creator.build(), [RXTimingSetupAnsPayload::cid()]);
 }
+
 #[test]
 fn test_rx_timing_setup_req_creator_bad_delay() {
     let mut creator = RXTimingSetupReqCreator::new();
@@ -172,11 +174,13 @@ fn test_tx_param_setup_req_creator() {
     let res = creator.build();
     assert_eq!(res, [TXParamSetupReqPayload::cid(), 0x1B]);
 }
+
 #[test]
 fn test_tx_param_setup_req_creator_bad_max_eirp() {
     let mut creator = TXParamSetupReqCreator::new();
     assert!(creator.set_max_eirp(8).is_err());
 }
+
 #[test]
 fn test_dl_channel_req_creator() {
     let mut creator = DlChannelReqCreator::new();
@@ -185,12 +189,14 @@ fn test_dl_channel_req_creator() {
     let res = creator.build();
     assert_eq!(res, [DlChannelReqPayload::cid(), 0x03, 0x12, 0x34, 0x56]);
 }
+
 #[test]
 fn test_device_time_req_creator() {
     let creator = DeviceTimeReqCreator::new();
     let res = creator.build();
     assert_eq!(res, [DeviceTimeReqPayload::cid()]);
 }
+
 #[test]
 fn test_device_time_ans_creator() {
     let mut creator = DeviceTimeAnsCreator::new();

--- a/encoding/tests/maccommands.rs
+++ b/encoding/tests/maccommands.rs
@@ -246,6 +246,7 @@ fn test_tx_param_setup_req() {
 fn test_tx_param_setup_ans() {
     test_helper!(TXParamSetupAns, TXParamSetupAnsPayload);
 }
+
 #[test]
 fn test_dl_channel_req() {
     let data = vec![1, 2, 3, 4];
@@ -258,6 +259,7 @@ fn test_dl_channel_req() {
         (frequency, Frequency::new_from_raw(&data[1..4])),
     );
 }
+
 #[test]
 fn test_dl_channel_ans() {
     let data = vec![0x3];
@@ -275,6 +277,7 @@ fn test_dl_channel_ans() {
 fn test_parse_mac_commands_empty_downlink() {
     assert_eq!(parse_mac_commands(&[], false).count(), 0);
 }
+
 #[test]
 fn test_device_time_req() {
     test_helper!(DeviceTimeReq, DeviceTimeReqPayload);

--- a/encoding/tests/maccommands.rs
+++ b/encoding/tests/maccommands.rs
@@ -229,8 +229,67 @@ fn test_rx_timing_setup_ans() {
 }
 
 #[test]
+fn test_tx_param_setup_req() {
+    let data = vec![0x0F];
+    test_helper!(
+        data,
+        TXParamSetupReq,
+        TXParamSetupReqPayload,
+        1,
+        (downlink_dwell_time, false),
+        (uplink_dwell_time, true),
+        (max_eirp, 36),
+    );
+}
+
+#[test]
+fn test_tx_param_setup_ans() {
+    test_helper!(TXParamSetupAns, TXParamSetupAnsPayload);
+}
+#[test]
+fn test_dl_channel_req() {
+    let data = vec![1, 2, 3, 4];
+    test_helper!(
+        data,
+        DlChannelReq,
+        DlChannelReqPayload,
+        4,
+        (channel_index, 1),
+        (frequency, Frequency::new_from_raw(&data[1..4])),
+    );
+}
+#[test]
+fn test_dl_channel_ans() {
+    let data = vec![0x3];
+    test_helper!(
+        data,
+        DlChannelAns,
+        DlChannelAnsPayload,
+        1,
+        (channel_freq_ack, true),
+        (uplink_freq_ack, true),
+    );
+}
+
+#[test]
 fn test_parse_mac_commands_empty_downlink() {
     assert_eq!(parse_mac_commands(&[], false).count(), 0);
+}
+#[test]
+fn test_device_time_req() {
+    test_helper!(DeviceTimeReq, DeviceTimeReqPayload);
+}
+#[test]
+fn test_device_time_ans() {
+    let data = vec![0x1, 0x2, 0x3, 0x4, 0x5];
+    test_helper!(
+        data,
+        DeviceTimeAns,
+        DeviceTimeAnsPayload,
+        5,
+        (seconds, 16909060),
+        (nano_seconds, 0x5 * 3906250),
+    );
 }
 
 #[test]

--- a/encoding/tests/maccommands.rs
+++ b/encoding/tests/maccommands.rs
@@ -230,7 +230,7 @@ fn test_rx_timing_setup_ans() {
 
 #[test]
 fn test_tx_param_setup_req() {
-    let data = vec![0x0F];
+    let data = vec![0b011110];
     test_helper!(
         data,
         TXParamSetupReq,
@@ -238,7 +238,7 @@ fn test_tx_param_setup_req() {
         1,
         (downlink_dwell_time, false),
         (uplink_dwell_time, true),
-        (max_eirp, 36),
+        (max_eirp, 33),
     );
 }
 


### PR DESCRIPTION
Adding the commands makes it easier to develop towards 1.0.4. As I added them here even 1.0.2 projects would have the new commands. Ideally these new commands could be behind a feature but that is not so easy to implement with the current macros.