### PR TITLE
Add repo-wide rules for the code formatting

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,23 @@
+# This file defines the Rust style for automatic reformatting.
+# See also https://rust-lang.github.io/rustfmt
+
+# Rust language edition.
+edition = "2021"
+
+# Line endings will be converted to \n.
+newline_style = "Unix"
+
+# The "Default" setting has a heuristic which splits lines too aggresively.
+use_small_heuristics = "Max"
+
+# Always put if else statements on multiple lines.
+single_line_if_else_max_width = 0
+
+# Version of the formatting rules to use.
+# version = "Two"
+
+# Max width of comments before wrapping.
+# comment_width = 100
+
+# Wrap comments above comment_width.
+# wrap_comments = true

--- a/device/src/async_device/lora_radio.rs
+++ b/device/src/async_device/lora_radio.rs
@@ -82,7 +82,8 @@ where
     }
 }
 
-/// Provide the LoRa physical layer rx/tx interface for boards supported by the external lora-phy crate
+/// Provide the LoRa physical layer rx/tx interface for boards supported by the external lora-phy
+/// crate
 impl<RK> PhyRxTx for LoRaRadio<RK>
 where
     RK: RadioKind + 'static,
@@ -97,8 +98,7 @@ where
             config.rf.frequency,
         )?;
         let mut tx_pkt_params =
-            self.lora
-                .create_tx_packet_params(8, false, true, false, &mdltn_params)?;
+            self.lora.create_tx_packet_params(8, false, true, false, &mdltn_params)?;
         let pw = match self.lora.get_board_type().into() {
             ChipType::Sx1276 | ChipType::Sx1277 | ChipType::Sx1278 | ChipType::Sx1279 => {
                 if config.pw > DEFAULT_DBM {
@@ -109,12 +109,8 @@ where
             }
             _ => config.pw,
         };
-        self.lora
-            .prepare_for_tx(&mdltn_params, pw.into(), false)
-            .await?;
-        self.lora
-            .tx(&mdltn_params, &mut tx_pkt_params, buffer, 0xffffff)
-            .await?;
+        self.lora.prepare_for_tx(&mdltn_params, pw.into(), false).await?;
+        self.lora.tx(&mdltn_params, &mut tx_pkt_params, buffer, 0xffffff).await?;
         Ok(0)
     }
 

--- a/device/src/async_device/radio.rs
+++ b/device/src/async_device/radio.rs
@@ -33,8 +33,8 @@ pub trait PhyRxTx: Sized {
     /// should only complete once data have been transmitted.
     async fn tx(&mut self, config: TxConfig, buf: &[u8]) -> Result<u32, Self::PhyError>;
 
-    /// Receive data into the provided buffer with the given tranciever configuration. The returned future
-    /// should only complete when RX data have been received.
+    /// Receive data into the provided buffer with the given tranciever configuration. The returned
+    /// future should only complete when RX data have been received.
     async fn rx(
         &mut self,
         config: RfConfig,

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -126,16 +126,8 @@ pub trait Timings {
 }
 
 pub enum JoinMode {
-    OTAA {
-        deveui: [u8; 8],
-        appeui: [u8; 8],
-        appkey: [u8; 16],
-    },
-    ABP {
-        newskey: AES128,
-        appskey: AES128,
-        devaddr: DevAddr<[u8; 4]>,
-    },
+    OTAA { deveui: [u8; 8], appeui: [u8; 8], appkey: [u8; 16] },
+    ABP { newskey: AES128, appskey: AES128, devaddr: DevAddr<[u8; 4]> },
 }
 
 #[allow(dead_code)]
@@ -152,11 +144,7 @@ where
         rng: RNG,
     ) -> Device<R, C, RNG, N> {
         let (shared, state) = match join_mode {
-            JoinMode::OTAA {
-                deveui,
-                appeui,
-                appkey,
-            } => (
+            JoinMode::OTAA { deveui, appeui, appkey } => (
                 Shared::new(
                     radio,
                     Some(Credentials::new(appeui, deveui, appkey)),
@@ -166,21 +154,13 @@ where
                 ),
                 State::new(),
             ),
-            JoinMode::ABP {
-                newskey,
-                appskey,
-                devaddr,
-            } => (
+            JoinMode::ABP { newskey, appskey, devaddr } => (
                 Shared::new(radio, None, region, Mac::default(), rng),
                 State::new_abp(newskey, appskey, devaddr),
             ),
         };
 
-        Device {
-            crypto: PhantomData::default(),
-            shared,
-            state: Some(state),
-        }
+        Device { crypto: PhantomData::default(), shared, state: Some(state) }
     }
 
     pub fn get_radio(&mut self) -> &mut R {
@@ -206,10 +186,7 @@ where
     }
 
     pub fn ready_to_send_data(&self) -> bool {
-        matches!(
-            &self.state.as_ref().unwrap(),
-            State::Session(session::Session::Idle(_))
-        )
+        matches!(&self.state.as_ref().unwrap(), State::Session(session::Session::Idle(_)))
     }
 
     pub fn send(
@@ -218,11 +195,7 @@ where
         fport: u8,
         confirmed: bool,
     ) -> Result<Response, Error<R::PhyError>> {
-        self.handle_event(Event::SendDataRequest(SendData {
-            data,
-            fport,
-            confirmed,
-        }))
+        self.handle_event(Event::SendDataRequest(SendData { data, fport, confirmed }))
     }
 
     pub fn get_fcnt_up(&self) -> Option<u32> {
@@ -235,9 +208,7 @@ where
 
     pub fn get_session_keys(&self) -> Option<SessionKeys> {
         if let State::Session(session) = &self.state.as_ref().unwrap() {
-            Some(SessionKeys::copy_from_session_data(
-                session.get_session_data(),
-            ))
+            Some(SessionKeys::copy_from_session_data(session.get_session_data()))
         } else {
             None
         }

--- a/device/src/mac.rs
+++ b/device/src/mac.rs
@@ -106,18 +106,13 @@ impl Mac {
 
     pub fn get_cmds(&mut self, macs: &mut Vec<MacCommand, 8>) {
         for _ in 0..self.adr_ans.get() {
-            macs.push(MacCommand::LinkADRAns(
-                LinkADRAnsPayload::new(&[0x07]).unwrap(),
-            ))
-            .unwrap();
+            macs.push(MacCommand::LinkADRAns(LinkADRAnsPayload::new(&[0x07]).unwrap())).unwrap();
         }
         self.adr_ans.clear();
 
         if self.rx_delay_ans.get() != 0 {
-            macs.push(MacCommand::RXTimingSetupAns(
-                RXTimingSetupAnsPayload::new(&[]).unwrap(),
-            ))
-            .unwrap();
+            macs.push(MacCommand::RXTimingSetupAns(RXTimingSetupAnsPayload::new(&[]).unwrap()))
+                .unwrap();
         }
         self.rx_delay_ans.clear();
     }

--- a/device/src/radio/types.rs
+++ b/device/src/radio/types.rs
@@ -69,10 +69,7 @@ pub(crate) struct RadioBuffer<const N: usize> {
 
 impl<const N: usize> RadioBuffer<N> {
     pub(crate) fn new() -> Self {
-        Self {
-            packet: [0; N],
-            pos: 0,
-        }
+        Self { packet: [0; N], pos: 0 }
     }
 
     pub(crate) fn clear(&mut self) {

--- a/device/src/region/dynamic_channel_plans/as923.rs
+++ b/device/src/region/dynamic_channel_plans/as923.rs
@@ -30,33 +30,12 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2, 7>
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 7] = [
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_12,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_11,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_10,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_9,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_8,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_250KHz,
-    }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_250KHz }),
     //ignore FSK data rate for now
 ];

--- a/device/src/region/dynamic_channel_plans/eu433.rs
+++ b/device/src/region/dynamic_channel_plans/eu433.rs
@@ -26,32 +26,11 @@ impl DynamicChannelRegion<3, 7> for EU433Region {
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 7] = [
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_12,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_11,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_10,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_9,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_8,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_250KHz,
-    }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_250KHz }),
 ];

--- a/device/src/region/dynamic_channel_plans/eu868.rs
+++ b/device/src/region/dynamic_channel_plans/eu868.rs
@@ -26,33 +26,12 @@ impl DynamicChannelRegion<3, 7> for EU868Region {
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 7] = [
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_12,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_11,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_10,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_9,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_8,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_250KHz,
-    }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_250KHz }),
     //ignore FSK data rate for now
 ];

--- a/device/src/region/dynamic_channel_plans/in865.rs
+++ b/device/src/region/dynamic_channel_plans/in865.rs
@@ -26,29 +26,11 @@ impl DynamicChannelRegion<3, 6> for IN865Region {
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 6] = [
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_12,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_11,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_10,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_9,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_8,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_125KHz,
-    }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
     //ignore FSK data rate for now
 ];

--- a/device/src/region/dynamic_channel_plans/mod.rs
+++ b/device/src/region/dynamic_channel_plans/mod.rs
@@ -112,32 +112,21 @@ impl<
         match channel_mask_control {
             0 | 1 | 2 | 3 | 4 => {
                 let base_index = channel_mask_control as usize * 2;
-                self.channel_mask
-                    .set_bank(base_index, channel_mask.get_index(0));
-                self.channel_mask
-                    .set_bank(base_index + 1, channel_mask.get_index(1));
+                self.channel_mask.set_bank(base_index, channel_mask.get_index(0));
+                self.channel_mask.set_bank(base_index + 1, channel_mask.get_index(1));
             }
             5 => {
                 let channel_mask: u16 =
                     channel_mask.get_index(0) as u16 | ((channel_mask.get_index(1) as u16) << 8);
-                self.channel_mask
-                    .set_bank(0, ((channel_mask & 0b1) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(1, ((channel_mask & 0b10) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(2, ((channel_mask & 0b100) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(3, ((channel_mask & 0b1000) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(4, ((channel_mask & 0b10000) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(5, ((channel_mask & 0b100000) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(6, ((channel_mask & 0b1000000) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(7, ((channel_mask & 0b10000000) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(8, ((channel_mask & 0b100000000) * 0xFF) as u8);
+                self.channel_mask.set_bank(0, ((channel_mask & 0b1) * 0xFF) as u8);
+                self.channel_mask.set_bank(1, ((channel_mask & 0b10) * 0xFF) as u8);
+                self.channel_mask.set_bank(2, ((channel_mask & 0b100) * 0xFF) as u8);
+                self.channel_mask.set_bank(3, ((channel_mask & 0b1000) * 0xFF) as u8);
+                self.channel_mask.set_bank(4, ((channel_mask & 0b10000) * 0xFF) as u8);
+                self.channel_mask.set_bank(5, ((channel_mask & 0b100000) * 0xFF) as u8);
+                self.channel_mask.set_bank(6, ((channel_mask & 0b1000000) * 0xFF) as u8);
+                self.channel_mask.set_bank(7, ((channel_mask & 0b10000000) * 0xFF) as u8);
+                self.channel_mask.set_bank(8, ((channel_mask & 0b100000000) * 0xFF) as u8);
             }
             6 => {
                 // all channels on

--- a/device/src/region/fixed_channel_plans/au915/datarates.rs
+++ b/device/src/region/fixed_channel_plans/au915/datarates.rs
@@ -1,59 +1,20 @@
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 16] = [
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_12,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_11,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_10,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_9,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_8,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_8,
-        bandwidth: Bandwidth::_500KHz,
-    }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_500KHz }),
     None, // LR-FHSS -- not currently supported
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_12,
-        bandwidth: Bandwidth::_500KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_11,
-        bandwidth: Bandwidth::_500KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_10,
-        bandwidth: Bandwidth::_500KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_9,
-        bandwidth: Bandwidth::_500KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_8,
-        bandwidth: Bandwidth::_500KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_500KHz,
-    }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_500KHz }),
     None, // RFU
     None,
 ];

--- a/device/src/region/fixed_channel_plans/mod.rs
+++ b/device/src/region/fixed_channel_plans/mod.rs
@@ -18,7 +18,11 @@ pub(crate) struct FixedChannelPlan<const D: usize, F: FixedChannelRegion<D>> {
 
 impl<const D: usize, F: FixedChannelRegion<D>> FixedChannelPlan<D, F> {
     pub fn set_125k_channels(&mut self, enabled: bool) {
-        let mask = if enabled { 0xFF } else { 0x00 };
+        let mask = if enabled {
+            0xFF
+        } else {
+            0x00
+        };
         self.channel_mask.set_bank(0, mask);
         self.channel_mask.set_bank(1, mask);
         self.channel_mask.set_bank(2, mask);
@@ -57,32 +61,21 @@ impl<const D: usize, F: FixedChannelRegion<D>> RegionHandler for FixedChannelPla
         match channel_mask_control {
             0 | 1 | 2 | 3 | 4 => {
                 let base_index = channel_mask_control as usize * 2;
-                self.channel_mask
-                    .set_bank(base_index, channel_mask.get_index(0));
-                self.channel_mask
-                    .set_bank(base_index + 1, channel_mask.get_index(1));
+                self.channel_mask.set_bank(base_index, channel_mask.get_index(0));
+                self.channel_mask.set_bank(base_index + 1, channel_mask.get_index(1));
             }
             5 => {
                 let channel_mask: u16 =
                     channel_mask.get_index(0) as u16 | ((channel_mask.get_index(1) as u16) << 8);
-                self.channel_mask
-                    .set_bank(0, ((channel_mask & 0b1) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(1, ((channel_mask & 0b10) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(2, ((channel_mask & 0b100) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(3, ((channel_mask & 0b1000) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(4, ((channel_mask & 0b10000) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(5, ((channel_mask & 0b100000) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(6, ((channel_mask & 0b1000000) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(7, ((channel_mask & 0b10000000) * 0xFF) as u8);
-                self.channel_mask
-                    .set_bank(8, ((channel_mask & 0b100000000) * 0xFF) as u8);
+                self.channel_mask.set_bank(0, ((channel_mask & 0b1) * 0xFF) as u8);
+                self.channel_mask.set_bank(1, ((channel_mask & 0b10) * 0xFF) as u8);
+                self.channel_mask.set_bank(2, ((channel_mask & 0b100) * 0xFF) as u8);
+                self.channel_mask.set_bank(3, ((channel_mask & 0b1000) * 0xFF) as u8);
+                self.channel_mask.set_bank(4, ((channel_mask & 0b10000) * 0xFF) as u8);
+                self.channel_mask.set_bank(5, ((channel_mask & 0b100000) * 0xFF) as u8);
+                self.channel_mask.set_bank(6, ((channel_mask & 0b1000000) * 0xFF) as u8);
+                self.channel_mask.set_bank(7, ((channel_mask & 0b10000000) * 0xFF) as u8);
+                self.channel_mask.set_bank(8, ((channel_mask & 0b100000000) * 0xFF) as u8);
             }
             6 => {
                 self.set_125k_channels(true);
@@ -110,7 +103,11 @@ impl<const D: usize, F: FixedChannelRegion<D>> RegionHandler for FixedChannelPla
                 self.last_tx_channel = channel;
                 // For the join frame, the randomly selected channel dictates the datarate
                 // When TODO above is implemented, this does not require changes
-                let datarate = if channel > 64 { DR::_4 } else { DR::_0 };
+                let datarate = if channel > 64 {
+                    DR::_4
+                } else {
+                    DR::_0
+                };
                 (
                     F::datarates()[datarate as usize].clone().unwrap(),
                     F::uplink_channels()[channel as usize],

--- a/device/src/region/fixed_channel_plans/us915/datarates.rs
+++ b/device/src/region/fixed_channel_plans/us915/datarates.rs
@@ -1,51 +1,18 @@
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 14] = [
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_10,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_9,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_8,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_125KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_8,
-        bandwidth: Bandwidth::_500KHz,
-    }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_500KHz }),
     None,
     None,
     None,
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_12,
-        bandwidth: Bandwidth::_500KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_11,
-        bandwidth: Bandwidth::_500KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_10,
-        bandwidth: Bandwidth::_500KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_9,
-        bandwidth: Bandwidth::_500KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_8,
-        bandwidth: Bandwidth::_500KHz,
-    }),
-    Some(Datarate {
-        spreading_factor: SpreadingFactor::_7,
-        bandwidth: Bandwidth::_500KHz,
-    }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_500KHz }),
 ];

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -255,12 +255,7 @@ impl Configuration {
         channel_mask_control: u8,
         channel_mask: ChannelMask<2>,
     ) {
-        mut_region_dispatch!(
-            self,
-            handle_link_adr_channel_mask,
-            channel_mask_control,
-            channel_mask
-        )
+        mut_region_dispatch!(self, handle_link_adr_channel_mask, channel_mask_control, channel_mask)
     }
 
     pub(crate) fn get_rx_delay(&self, frame: &Frame, window: &Window) -> u32 {

--- a/device/src/types.rs
+++ b/device/src/types.rs
@@ -19,11 +19,7 @@ pub(crate) type DevNonce = lorawan::parser::DevNonce<[u8; 2]>;
 
 impl Credentials {
     pub fn new(appeui: AppEui, deveui: DevEui, appkey: [u8; 16]) -> Credentials {
-        Credentials {
-            deveui,
-            appeui,
-            appkey: appkey.into(),
-        }
+        Credentials { deveui, appeui, appkey: appkey.into() }
     }
 
     pub fn appeui(&self) -> &AppEui {
@@ -64,10 +60,7 @@ impl Credentials {
         let devnonce_copy = DevNonce::new(devnonce).unwrap();
 
         buf.extend_from_slice(vec).unwrap();
-        (
-            devnonce_copy,
-            region.create_tx_config(rng, datarate, &Frame::Join),
-        )
+        (devnonce_copy, region.create_tx_config(rng, datarate, &Frame::Join))
     }
 }
 
@@ -87,11 +80,7 @@ impl SessionKeys {
             | (session_devaddr[2] as u32) << 8
             | (session_devaddr[1] as u32) << 16
             | (session_devaddr[0] as u32) << 24;
-        SessionKeys {
-            newskey: *session_data.newskey(),
-            appskey: *session_data.appskey(),
-            devaddr,
-        }
+        SessionKeys { newskey: *session_data.newskey(), appskey: *session_data.appskey(), devaddr }
     }
 }
 use core::fmt;

--- a/encoding/benches/lorawan.rs
+++ b/encoding/benches/lorawan.rs
@@ -60,11 +60,7 @@ fn bench_complete_data_payload_fhdr(c: &mut Criterion) {
         })
     });
     let n = cnt.load(Ordering::SeqCst);
-    println!(
-        "Approximate memory usage per iteration: {} from {}",
-        GLOBAL.get_sum() / n,
-        n
-    );
+    println!("Approximate memory usage per iteration: {} from {}", GLOBAL.get_sum() / n, n);
 }
 
 fn bench_complete_data_payload_mic_validation(c: &mut Criterion) {
@@ -86,11 +82,7 @@ fn bench_complete_data_payload_mic_validation(c: &mut Criterion) {
         })
     });
     let n = cnt.load(Ordering::SeqCst);
-    println!(
-        "Approximate memory usage per iteration: {} from {}",
-        GLOBAL.get_sum() / n,
-        n
-    );
+    println!("Approximate memory usage per iteration: {} from {}", GLOBAL.get_sum() / n, n);
 }
 
 fn bench_complete_data_payload_decrypt(c: &mut Criterion) {
@@ -108,21 +100,14 @@ fn bench_complete_data_payload_decrypt(c: &mut Criterion) {
 
             if let PhyPayload::Data(DataPayload::Encrypted(data_payload)) = phy {
                 assert_eq!(
-                    data_payload
-                        .decrypt(None, Some(&key), 1)
-                        .unwrap()
-                        .frm_payload(),
+                    data_payload.decrypt(None, Some(&key), 1).unwrap().frm_payload(),
                     Ok(FRMPayload::Data(&payload[..]))
                 );
             }
         })
     });
     let n = cnt.load(Ordering::SeqCst);
-    println!(
-        "Approximate memory usage per iteration: {} from {}",
-        GLOBAL.get_sum() / n,
-        n
-    );
+    println!("Approximate memory usage per iteration: {} from {}", GLOBAL.get_sum() / n, n);
 }
 
 pub type Cmac = cmac::Cmac<Aes128>;

--- a/encoding/src/creator.rs
+++ b/encoding/src/creator.rs
@@ -55,20 +55,15 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> JoinAcceptCreator<D, F> {
             return Err("data slice is too short");
         }
         d[0] = 0x20;
-        Ok(Self {
-            data,
-            with_c_f_list: false,
-            encrypted: false,
-            factory,
-        })
+        Ok(Self { data, with_c_f_list: false, encrypted: false, factory })
     }
 
     /// Sets the AppNonce of the JoinAccept to the provided value.
     ///
     /// # Argument
     ///
-    /// * app_nonce - instance of lorawan::parser::AppNonce or anything that can
-    ///   be converted into it.
+    /// * app_nonce - instance of lorawan::parser::AppNonce or anything that can be converted into
+    ///   it.
     pub fn set_app_nonce<H: AsRef<[u8]>, T: Into<parser::AppNonce<H>>>(
         &mut self,
         app_nonce: T,
@@ -83,8 +78,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> JoinAcceptCreator<D, F> {
     ///
     /// # Argument
     ///
-    /// * net_id - instance of lorawan::parser::NwkAddr or anything that can
-    ///   be converted into it.
+    /// * net_id - instance of lorawan::parser::NwkAddr or anything that can be converted into it.
     pub fn set_net_id<H: AsRef<[u8]>, T: Into<parser::NwkAddr<H>>>(
         &mut self,
         net_id: T,
@@ -99,8 +93,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> JoinAcceptCreator<D, F> {
     ///
     /// # Argument
     ///
-    /// * dev_addr - instance of lorawan::parser::DevAddr or anything that can
-    ///   be converted into it.
+    /// * dev_addr - instance of lorawan::parser::DevAddr or anything that can be converted into it.
     pub fn set_dev_addr<H: AsRef<[u8]>, T: Into<parser::DevAddr<H>>>(
         &mut self,
         dev_addr: T,
@@ -115,8 +108,8 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> JoinAcceptCreator<D, F> {
     ///
     /// # Argument
     ///
-    /// * dl_settings - instance of lorawan::maccommands::DLSettings or anything
-    ///   that can be converted into it.
+    /// * dl_settings - instance of lorawan::maccommands::DLSettings or anything that can be
+    ///   converted into it.
     pub fn set_dl_settings<T: Into<DLSettings>>(&mut self, dl_settings: T) -> &mut Self {
         let converted = dl_settings.into();
         self.data.as_mut()[11] = converted.raw_value();
@@ -213,12 +206,7 @@ impl JoinAcceptCreator<[u8; 33], DefaultFactory> {
     pub fn new() -> Self {
         let mut data = [0; 33];
         data[0] = 0x20;
-        Self {
-            data,
-            with_c_f_list: false,
-            encrypted: false,
-            factory: DefaultFactory,
-        }
+        Self { data, with_c_f_list: false, encrypted: false, factory: DefaultFactory }
     }
 }
 
@@ -252,8 +240,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory> JoinRequestCreator<D, F> {
     ///
     /// # Argument
     ///
-    /// * app_eui - instance of lorawan::parser::EUI64 or anything that can
-    ///   be converted into it.
+    /// * app_eui - instance of lorawan::parser::EUI64 or anything that can be converted into it.
     pub fn set_app_eui<H: AsRef<[u8]>, T: Into<parser::EUI64<H>>>(
         &mut self,
         app_eui: T,
@@ -268,8 +255,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory> JoinRequestCreator<D, F> {
     ///
     /// # Argument
     ///
-    /// * dev_eui - instance of lorawan::parser::EUI64 or anything that can
-    ///   be converted into it.
+    /// * dev_eui - instance of lorawan::parser::EUI64 or anything that can be converted into it.
     pub fn set_dev_eui<H: AsRef<[u8]>, T: Into<parser::EUI64<H>>>(
         &mut self,
         dev_eui: T,
@@ -284,8 +270,8 @@ impl<D: AsMut<[u8]>, F: CryptoFactory> JoinRequestCreator<D, F> {
     ///
     /// # Argument
     ///
-    /// * dev_nonce - instance of lorawan::parser::DevNonce or anything that can
-    ///   be converted into it.
+    /// * dev_nonce - instance of lorawan::parser::DevNonce or anything that can be converted into
+    ///   it.
     pub fn set_dev_nonce<H: AsRef<[u8]>, T: Into<parser::DevNonce<H>>>(
         &mut self,
         dev_nonce: T,
@@ -344,12 +330,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> DataPayloadCreator<D, F> {
             return Err("data slice is too short");
         }
         d[0] = 0x40;
-        Ok(DataPayloadCreator {
-            data,
-            data_f_port: None,
-            fcnt: 0,
-            factory,
-        })
+        Ok(DataPayloadCreator { data, data_f_port: None, fcnt: 0, factory })
     }
 
     /// Sets whether the packet is uplink or downlink.
@@ -388,8 +369,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> DataPayloadCreator<D, F> {
     ///
     /// # Argument
     ///
-    /// * dev_addr - instance of lorawan::parser::DevAddr or anything that can
-    ///   be converted into it.
+    /// * dev_addr - instance of lorawan::parser::DevAddr or anything that can be converted into it.
     pub fn set_dev_addr<H: AsRef<[u8]>, T: Into<parser::DevAddr<H>>>(
         &mut self,
         dev_addr: T,
@@ -450,10 +430,9 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> DataPayloadCreator<D, F> {
     /// # Argument
     ///
     /// * payload - the FRMPayload (application) to be sent.
-    /// * nwk_skey - the key to be used for setting the MIC and possibly for
-    ///   MAC command encryption.
-    /// * app_skey - the key to be used for payload encryption if fport not 0,
-    ///   otherwise nwk_skey is only used.
+    /// * nwk_skey - the key to be used for setting the MIC and possibly for MAC command encryption.
+    /// * app_skey - the key to be used for payload encryption if fport not 0, otherwise nwk_skey is
+    ///   only used.
     ///
     ///
     /// # Example
@@ -573,11 +552,6 @@ impl DataPayloadCreator<GenericArray<u8, U256>, DefaultFactory> {
     pub fn new() -> Self {
         let mut data: GenericArray<u8, U256> = GenericArray::default();
         data[0] = 0x40;
-        Self {
-            data,
-            data_f_port: None,
-            fcnt: 0,
-            factory: DefaultFactory,
-        }
+        Self { data, data_f_port: None, fcnt: 0, factory: DefaultFactory }
     }
 }

--- a/encoding/src/default_crypto.rs
+++ b/encoding/src/default_crypto.rs
@@ -174,10 +174,10 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> DecryptedDataPayload<T> {
     ///
     /// # Argument
     ///
-    /// * nwk_skey - the Network Session key used to decrypt the mac commands in case the payload
-    ///     is transporting those.
-    /// * app_skey - the Application Session key used to decrypt the application payload in case
-    ///     the payload is transporting that.
+    /// * nwk_skey - the Network Session key used to decrypt the mac commands in case the payload is
+    ///   transporting those.
+    /// * app_skey - the Application Session key used to decrypt the application payload in case the
+    ///   payload is transporting that.
     /// * fcnt - the counter used to encrypt the payload.
     ///
     /// # Examples

--- a/encoding/src/maccommands.rs
+++ b/encoding/src/maccommands.rs
@@ -377,11 +377,7 @@ macro_rules! create_value_reader_fn {
 ///     lorawan::maccommands::parse_mac_commands(&data[..], true).collect();
 /// ```
 pub fn parse_mac_commands(data: &[u8], uplink: bool) -> MacCommandIterator {
-    MacCommandIterator {
-        index: 0,
-        data,
-        uplink,
-    }
+    MacCommandIterator { index: 0, data, uplink }
 }
 
 /// Implementation of iterator for mac commands.
@@ -492,9 +488,7 @@ impl<'de, const N: usize> serde::de::Visitor<'de> for ChannelMaskDeserializer<N>
         let mut index = 0;
         while let Some(el) = seq.next_element()? {
             if index >= N {
-                return Err(serde::de::Error::custom(
-                    "ChannelMask has too many elements",
-                ));
+                return Err(serde::de::Error::custom("ChannelMask has too many elements"));
             } else {
                 arr[index] = el;
                 index += 1;
@@ -760,9 +754,9 @@ impl<'a> DevStatusAnsPayload<'a> {
     create_value_reader_fn!(
         /// The battery level of the device.
         ///
-        /// Note: 0 means that the device is powered by an external source, 255 means that the device
-        /// was unable to measure its battery level, any other value represents the actual battery
-        /// level.
+        /// Note: 0 means that the device is powered by an external source, 255 means that the
+        /// device was unable to measure its battery level, any other value represents the
+        /// actual battery level.
         battery,
         0
     );

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -345,7 +345,8 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>, F: CryptoFactory> EncryptedJoinAcceptPayload<
 /// DecryptedJoinAcceptPayload represents a decrypted JoinAccept.
 ///
 /// It can be built either directly through the [new](#method.new) or using the
-/// [EncryptedJoinAcceptPayload.decrypt](struct.EncryptedJoinAcceptPayload.html#method.decrypt) function.
+/// [EncryptedJoinAcceptPayload.decrypt](struct.EncryptedJoinAcceptPayload.html#method.decrypt)
+/// function.
 #[derive(Debug, PartialEq, Eq)]
 pub struct DecryptedJoinAcceptPayload<T, F>(T, F);
 
@@ -554,10 +555,7 @@ pub trait DataHeader {
 
     /// Gives the FHDR of the DataPayload.
     fn fhdr(&self) -> FHDR {
-        FHDR::new_from_raw(
-            &self.as_data_bytes()[1..(1 + self.fhdr_length())],
-            self.is_uplink(),
-        )
+        FHDR::new_from_raw(&self.as_data_bytes()[1..(1 + self.fhdr_length())], self.is_uplink())
     }
 
     /// Gives whether the frame is confirmed
@@ -665,10 +663,10 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>, F: CryptoFactory> EncryptedDataPayload<T, F> 
     ///
     /// # Argument
     ///
-    /// * nwk_skey - the Network Session key used to decrypt the mac commands in case the payload
-    ///     is transporting those.
-    /// * app_skey - the Application Session key used to decrypt the application payload in case
-    ///     the payload is transporting that.
+    /// * nwk_skey - the Network Session key used to decrypt the mac commands in case the payload is
+    ///   transporting those.
+    /// * app_skey - the Application Session key used to decrypt the application payload in case the
+    ///   payload is transporting that.
     /// * fcnt - the counter used to encrypt the payload.
     ///
     /// # Examples
@@ -816,9 +814,9 @@ where
     let bytes = data.as_ref();
     check_phy_data(bytes)?;
     match MHDR(bytes[0]).mtype() {
-        MType::JoinRequest => Ok(PhyPayload::JoinRequest(
-            JoinRequestPayload::new_with_factory(data, factory)?,
-        )),
+        MType::JoinRequest => {
+            Ok(PhyPayload::JoinRequest(JoinRequestPayload::new_with_factory(data, factory)?))
+        }
         MType::JoinAccept => Ok(PhyPayload::JoinAccept(JoinAcceptPayload::Encrypted(
             EncryptedJoinAcceptPayload::new_with_factory(data, factory)?,
         ))),

--- a/encoding/tests/lorawan.rs
+++ b/encoding/tests/lorawan.rs
@@ -112,10 +112,7 @@ fn data_payload_with_f_opts() -> Vec<u8> {
 }
 
 fn app_key() -> [u8; 16] {
-    [
-        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
-        0xff,
-    ]
+    [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]
 }
 
 #[test]
@@ -147,18 +144,14 @@ fn test_mhdr_major() {
 
 #[test]
 fn test_parse_phy_payload_with_too_few_bytes_is_err() {
-    let bytes = vec![
-        0x80, 0x04, 0x03, 0x02, 0x01, 0x00, 0xff, 0x01, 0x02, 0x03, 0x04,
-    ];
+    let bytes = vec![0x80, 0x04, 0x03, 0x02, 0x01, 0x00, 0xff, 0x01, 0x02, 0x03, 0x04];
     let phy = parse(bytes);
     assert!(phy.is_err());
 }
 
 #[test]
 fn test_parse_phy_payload_with_unsupported_major_versoin() {
-    let bytes = vec![
-        0x81, 0x04, 0x03, 0x02, 0x01, 0x00, 0xff, 0x01, 0x02, 0x03, 0x04, 0x05,
-    ];
+    let bytes = vec![0x81, 0x04, 0x03, 0x02, 0x01, 0x00, 0xff, 0x01, 0x02, 0x03, 0x04, 0x05];
     let phy = parse(bytes);
 
     // this is now part of the API.
@@ -170,9 +163,7 @@ fn test_parse_join_request_payload() {
     let phy = parse(phy_join_request_payload());
     assert_eq!(
         phy,
-        Ok(PhyPayload::JoinRequest(
-            JoinRequestPayload::new(phy_join_request_payload()).unwrap()
-        ))
+        Ok(PhyPayload::JoinRequest(JoinRequestPayload::new(phy_join_request_payload()).unwrap()))
     );
 }
 
@@ -201,24 +192,16 @@ fn test_parse_data_payload() {
 #[test]
 fn test_parse_data_payload_no_panic_when_bad_packet() {
     // This reproduces a panic from https://github.com/ivajloip/rust-lorawan/issues/94.
-    let data = vec![
-        0x40, 0x04, 0x03, 0x02, 0x01, 0x85, 0x01, 0x00, 0xd6, 0xc3, 0xb5, 0x82,
-    ];
+    let data = vec![0x40, 0x04, 0x03, 0x02, 0x01, 0x85, 0x01, 0x00, 0xd6, 0xc3, 0xb5, 0x82];
     let phy = parse(data);
-    assert_eq!(
-        phy.err(),
-        Some("can not build EncryptedDataPayload from the provided data")
-    );
+    assert_eq!(phy.err(), Some("can not build EncryptedDataPayload from the provided data"));
 }
 
 #[test]
 fn test_parse_data_payload_no_panic_when_too_short_packet() {
     let data = vec![0x40, 0x04, 0x03, 0x02, 0x01];
     let phy = EncryptedDataPayload::new(data);
-    assert_eq!(
-        phy.err(),
-        Some("can not build EncryptedDataPayload from the provided data")
-    );
+    assert_eq!(phy.err(), Some("can not build EncryptedDataPayload from the provided data"));
 }
 
 #[test]
@@ -253,10 +236,7 @@ fn test_new_join_accept_c_f_list_empty() {
 fn test_join_accept_app_nonce_extraction() {
     let decrypted_phy = new_decrypted_join_accept();
     let expected = vec![3, 2, 1];
-    assert_eq!(
-        decrypted_phy.app_nonce(),
-        AppNonce::new(&expected[..]).unwrap()
-    );
+    assert_eq!(decrypted_phy.app_nonce(), AppNonce::new(&expected[..]).unwrap());
 }
 
 #[test]
@@ -322,12 +302,9 @@ fn test_validate_data_mic_when_not_ok() {
 
 #[test]
 fn test_new_data_payload_is_none_if_bytes_too_short() {
-    let bytes = &[
-        0x80, 0x04, 0x03, 0x02, 0x01, 0x00, 0xff, 0x01, 0x02, 0x03, 0x04,
-    ];
-    let bytes_with_fopts = &[
-        0x00, 0x04, 0x03, 0x02, 0x01, 0x01, 0xff, 0x04, 0x01, 0x02, 0x03, 0x04,
-    ];
+    let bytes = &[0x80, 0x04, 0x03, 0x02, 0x01, 0x00, 0xff, 0x01, 0x02, 0x03, 0x04];
+    let bytes_with_fopts =
+        &[0x00, 0x04, 0x03, 0x02, 0x01, 0x01, 0xff, 0x04, 0x01, 0x02, 0x03, 0x04];
 
     assert!(EncryptedDataPayload::new(bytes).is_err());
     assert!(EncryptedDataPayload::new(bytes_with_fopts).is_err());
@@ -335,9 +312,7 @@ fn test_new_data_payload_is_none_if_bytes_too_short() {
 
 #[test]
 fn test_f_port_could_be_absent_in_data_payload() {
-    let bytes = &[
-        0x80, 0x04, 0x03, 0x02, 0x01, 0x00, 0xff, 0x04, 0x01, 0x02, 0x03, 0x04,
-    ];
+    let bytes = &[0x80, 0x04, 0x03, 0x02, 0x01, 0x00, 0xff, 0x04, 0x01, 0x02, 0x03, 0x04];
     let data_payload = EncryptedDataPayload::new(bytes).unwrap();
     assert!(data_payload.f_port().is_none());
 }
@@ -436,9 +411,7 @@ fn test_decrypt_downlink_missing_f_port_bug() {
     .unwrap();
     let key = AES128([1; 16]);
     let fcnt = 0;
-    assert!(encrypted_payload
-        .decrypt(Some(&key), None, fcnt as u32)
-        .is_ok());
+    assert!(encrypted_payload.decrypt(Some(&key), None, fcnt as u32).is_ok());
 }
 
 #[test]
@@ -479,10 +452,7 @@ fn test_data_payload_uplink_creator() {
         .set_fctrl(&fctrl) // ADR: true, all others: false
         .set_fcnt(1);
 
-    assert_eq!(
-        phy.build(b"hello", &[], &nwk_skey, &app_skey).unwrap(),
-        &phy_dataup_payload()[..]
-    );
+    assert_eq!(phy.build(b"hello", &[], &nwk_skey, &app_skey).unwrap(), &phy_dataup_payload()[..]);
 }
 
 #[test]
@@ -499,13 +469,7 @@ fn test_long_data_payload_uplink_creator() {
         .set_fcnt(0);
 
     assert_eq!(
-        phy.build(
-            &long_data_payload().into_bytes()[..],
-            &[],
-            &nwk_skey,
-            &app_skey
-        )
-        .unwrap(),
+        phy.build(&long_data_payload().into_bytes()[..], &[], &nwk_skey, &app_skey).unwrap(),
         &phy_long_dataup_payload()[..]
     );
 }
@@ -565,17 +529,10 @@ fn test_data_payload_creator_when_mac_commands_in_payload() {
     let nwk_skey = AES128([1; 16]);
     let mac_cmd1 = MacCommand::LinkCheckReq(LinkCheckReqPayload());
     let mut mac_cmd2 = LinkADRAnsCreator::new();
-    mac_cmd2
-        .set_channel_mask_ack(true)
-        .set_data_rate_ack(false)
-        .set_tx_power_ack(true);
+    mac_cmd2.set_channel_mask_ack(true).set_data_rate_ack(false).set_tx_power_ack(true);
     let mut cmds: Vec<&dyn SerializableMacCommand> = Vec::new();
     cmds.extend_from_slice(&[&mac_cmd1, &mac_cmd2]);
-    phy.set_confirmed(false)
-        .set_uplink(true)
-        .set_f_port(0)
-        .set_dev_addr(&[4, 3, 2, 1])
-        .set_fcnt(0);
+    phy.set_confirmed(false).set_uplink(true).set_f_port(0).set_dev_addr(&[4, 3, 2, 1]).set_fcnt(0);
     assert_eq!(
         phy.build(b"", &cmds[..], &nwk_skey, &nwk_skey).unwrap(),
         &data_payload_with_fport_zero()[..]
@@ -588,16 +545,10 @@ fn test_data_payload_creator_when_mac_commands_in_f_opts() {
     let nwk_skey = AES128([1; 16]);
     let mac_cmd1 = MacCommand::LinkCheckReq(LinkCheckReqPayload());
     let mut mac_cmd2 = LinkADRAnsCreator::new();
-    mac_cmd2
-        .set_channel_mask_ack(true)
-        .set_data_rate_ack(false)
-        .set_tx_power_ack(true);
+    mac_cmd2.set_channel_mask_ack(true).set_data_rate_ack(false).set_tx_power_ack(true);
     let mut cmds: Vec<&dyn SerializableMacCommand> = Vec::new();
     cmds.extend_from_slice(&[&mac_cmd1, &mac_cmd2]);
-    phy.set_confirmed(false)
-        .set_uplink(true)
-        .set_dev_addr(&[4, 3, 2, 1])
-        .set_fcnt(0);
+    phy.set_confirmed(false).set_uplink(true).set_dev_addr(&[4, 3, 2, 1]).set_fcnt(0);
 
     assert_eq!(
         phy.build(b"", &cmds[..], &nwk_skey, &nwk_skey).unwrap(),
@@ -624,10 +575,7 @@ fn test_join_request_app_eui_extraction() {
 fn test_join_request_dev_nonce_extraction() {
     let data = phy_join_request_payload();
     let join_request = JoinRequestPayload::new(&data[..]).unwrap();
-    assert_eq!(
-        join_request.dev_nonce(),
-        DevNonce::new(&data[17..19]).unwrap()
-    );
+    assert_eq!(join_request.dev_nonce(), DevNonce::new(&data[17..19]).unwrap());
 }
 
 #[test]

--- a/encoding/tests/maccommandcreator.rs
+++ b/encoding/tests/maccommandcreator.rs
@@ -53,11 +53,8 @@ fn test_link_adr_req_creator_bad_tx_power() {
 #[test]
 fn test_link_adr_ans_creator() {
     let mut creator = LinkADRAnsCreator::new();
-    let res = creator
-        .set_channel_mask_ack(true)
-        .set_data_rate_ack(true)
-        .set_tx_power_ack(true)
-        .build();
+    let res =
+        creator.set_channel_mask_ack(true).set_data_rate_ack(true).set_tx_power_ack(true).build();
     assert_eq!(res, [0x03, 0x07]);
 }
 
@@ -78,10 +75,7 @@ fn test_duty_cycle_ans_creator() {
 #[test]
 fn test_rx_param_setup_req_creator() {
     let mut creator = RXParamSetupReqCreator::new();
-    let res = creator
-        .set_dl_settings(0xcd)
-        .set_frequency(&[0x12, 0x34, 0x56])
-        .build();
+    let res = creator.set_dl_settings(0xcd).set_frequency(&[0x12, 0x34, 0x56]).build();
     assert_eq!(res, [RXParamSetupReqPayload::cid(), 0xcd, 0x12, 0x34, 0x56]);
 }
 
@@ -130,19 +124,13 @@ fn test_new_channel_req_creator() {
         .set_frequency(&[0x12, 0x34, 0x56])
         .set_data_rate_range(0x53)
         .build();
-    assert_eq!(
-        res,
-        [NewChannelReqPayload::cid(), 0x0f, 0x12, 0x34, 0x56, 0x53]
-    );
+    assert_eq!(res, [NewChannelReqPayload::cid(), 0x0f, 0x12, 0x34, 0x56, 0x53]);
 }
 
 #[test]
 fn test_new_channel_ans_creator() {
     let mut creator = NewChannelAnsCreator::new();
-    let res = creator
-        .set_channel_frequency_ack(true)
-        .set_data_rate_range_ack(true)
-        .build();
+    let res = creator.set_channel_frequency_ack(true).set_data_rate_range_ack(true).build();
     assert_eq!(res, [NewChannelAnsPayload::cid(), 0x03]);
 }
 
@@ -209,15 +197,10 @@ fn test_device_time_ans_creator() {
 #[test]
 fn test_build_mac_commands() {
     let rx_timing_setup_req = RXTimingSetupReqPayload::new_as_mac_cmd(&[0x02]).unwrap().0;
-    let dev_status_ans = DevStatusAnsPayload::new_as_mac_cmd(&[0xfe, 0x3f])
-        .unwrap()
-        .0;
+    let dev_status_ans = DevStatusAnsPayload::new_as_mac_cmd(&[0xfe, 0x3f]).unwrap().0;
     let cmds: Vec<&dyn SerializableMacCommand> = vec![&rx_timing_setup_req, &dev_status_ans];
     let expected_len = mac_commands_len(&cmds[..]);
     let mut res = vec![0; expected_len];
-    assert_eq!(
-        build_mac_commands(&cmds[..], &mut res[..]),
-        Ok(expected_len)
-    );
+    assert_eq!(build_mac_commands(&cmds[..], &mut res[..]), Ok(expected_len));
     assert_eq!(res, &vec![0x08, 0x02, 0x06, 0xfe, 0x3f][..]);
 }

--- a/encoding/tests/maccommands.rs
+++ b/encoding/tests/maccommands.rs
@@ -48,14 +48,7 @@ fn test_link_check_req_new() {
 #[test]
 fn test_link_check_ans_new() {
     let data = vec![0xa, 0x0f];
-    test_helper!(
-        data,
-        LinkCheckAns,
-        LinkCheckAnsPayload,
-        2,
-        (margin, 10),
-        (gateway_count, 15),
-    );
+    test_helper!(data, LinkCheckAns, LinkCheckAnsPayload, 2, (margin, 10), (gateway_count, 15),);
 }
 
 #[test]
@@ -164,14 +157,7 @@ fn test_dev_status_req() {
 #[test]
 fn test_dev_status_ans() {
     let data = vec![0xfe, 0x3f];
-    test_helper!(
-        data,
-        DevStatusAns,
-        DevStatusAnsPayload,
-        2,
-        (battery, 254),
-        (margin, -1),
-    );
+    test_helper!(data, DevStatusAns, DevStatusAnsPayload, 2, (battery, 254), (margin, -1),);
 }
 
 #[test]
@@ -214,13 +200,7 @@ fn test_new_channel_ans() {
 #[test]
 fn test_rx_timing_setup_req() {
     let data = vec![0x02];
-    test_helper!(
-        data,
-        RXTimingSetupReq,
-        RXTimingSetupReqPayload,
-        1,
-        (delay, 2),
-    );
+    test_helper!(data, RXTimingSetupReq, RXTimingSetupReqPayload, 1, (delay, 2),);
 }
 
 #[test]
@@ -304,10 +284,7 @@ fn test_parse_mac_commands_empty_uplink() {
 fn test_parse_mac_commands_with_multiple_cmds() {
     let data = mac_cmds_payload();
     let mut commands = parse_mac_commands(&data[..], true);
-    assert_eq!(
-        commands.next(),
-        Some(MacCommand::LinkCheckReq(LinkCheckReqPayload()))
-    );
+    assert_eq!(commands.next(), Some(MacCommand::LinkCheckReq(LinkCheckReqPayload())));
     let expected = LinkADRAnsPayload::new_as_mac_cmd(&data[2..]).unwrap().0;
     assert_eq!(commands.next(), Some(expected));
 }
@@ -319,16 +296,12 @@ fn test_parse_mac_commands_with_multiple_cmds_with_payloads() {
 
     assert_eq!(
         commands.next(),
-        Some(MacCommand::LinkADRReq(
-            LinkADRReqPayload::new(&[0, 0, 0, 112]).unwrap()
-        ))
+        Some(MacCommand::LinkADRReq(LinkADRReqPayload::new(&[0, 0, 0, 112]).unwrap()))
     );
 
     assert_eq!(
         commands.next(),
-        Some(MacCommand::LinkADRReq(
-            LinkADRReqPayload::new(&[0, 0, 255, 0]).unwrap()
-        ))
+        Some(MacCommand::LinkADRReq(LinkADRReqPayload::new(&[0, 0, 255, 0]).unwrap()))
     );
 }
 
@@ -417,9 +390,7 @@ fn test_mac_commands_len_with_creators() {
 #[test]
 fn test_mac_commands_len_with_mac_cmds() {
     let rx_timing_setup_req = RXTimingSetupReqPayload::new_as_mac_cmd(&[0x02]).unwrap().0;
-    let dev_status_ans = DevStatusAnsPayload::new_as_mac_cmd(&[0xfe, 0x3f])
-        .unwrap()
-        .0;
+    let dev_status_ans = DevStatusAnsPayload::new_as_mac_cmd(&[0xfe, 0x3f]).unwrap().0;
     let cmds: Vec<&dyn SerializableMacCommand> = vec![&rx_timing_setup_req, &dev_status_ans];
 
     assert_eq!(mac_commands_len(&cmds[..]), 5);


### PR DESCRIPTION
I have noticed a few PR that wrapped comments back and forth recently and in an attempt to stop this, I propose some formatting rules. I am looking forward to discussing them and agreeing on a set of rules that the tool will always apply. I ran the formatting and I have included the relevant result. I am not 100% happy with it, but I can live with it.