### PR TITLE
Add derives to make Lora Configuration (Region, JoinMode) serializable and testable

### DIFF
--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -125,6 +125,8 @@ pub trait Timings {
     fn get_rx_window_duration_ms(&self) -> u32;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum JoinMode {
     OTAA { deveui: [u8; 8], appeui: [u8; 8], appkey: [u8; 16] },
     ABP { newskey: AES128, appskey: AES128, devaddr: DevAddr<[u8; 4]> },

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -52,7 +52,7 @@ pub enum DR {
     _15 = 15,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Region {
     AS923_1,


### PR DESCRIPTION
While trying to store storing LoRaWAN configuration data in Flash we tried to serialize the Region and JoinMode, but the latter has not derived the serde traits. This PR adds derived that allow serde use for JoinMode, and make Region and JoinMode copyable for moving and testing purposes, and comparable for unit test purposes.