### PR TITLE
refactor mac for state machine implementation

### DIFF
--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -1,9 +1,12 @@
 //! Asynchronous Device using Rust async-await for driving the state machine,
 //! and allowing asynchronous radio implementations.
-use super::mac::Mac;
+use super::mac::uplink::Uplink;
 
-use super::region::{Frame, Window};
-pub use super::{region, region::Region, types::*, JoinMode, SendData, Timings};
+pub use super::{region, region::Region, JoinMode, SendData, Timings};
+use super::{
+    region::{Frame, Window},
+    Credentials,
+};
 use core::marker::PhantomData;
 use futures::{future::select, future::Either, pin_mut};
 use generic_array::{typenum::U256, GenericArray};
@@ -95,7 +98,7 @@ where
     phy: Phy<R, G>,
     timer: T,
     session: Option<SessionData>,
-    mac: Mac,
+    mac: Uplink,
     radio_buffer: RadioBuffer<N>,
     datarate: DR,
 }
@@ -163,7 +166,7 @@ where
             crypto: PhantomData,
             phy: Phy { radio, rng },
             session,
-            mac: Mac::default(),
+            mac: Uplink::default(),
             radio_buffer: RadioBuffer::new(),
             timer,
             datarate: region.get_default_datarate(),
@@ -335,7 +338,7 @@ where
                             );
 
                             if confirmed {
-                                self.mac.set_confirmed();
+                                self.mac.set_downlink_confirmation();
                             }
 
                             match decrypted.frm_payload() {
@@ -392,9 +395,9 @@ where
                     DataPayloadCreator::default();
 
                 let mut fctrl = FCtrl(0x0, true);
-                if self.mac.is_confirmed() {
+                if self.mac.confirms_downlink() {
                     fctrl.set_ack();
-                    self.mac.clear_confirmed();
+                    self.mac.clear_downlink_confirmation();
                 }
 
                 phy.set_confirmed(confirmed)

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -2,8 +2,6 @@
 #![cfg_attr(feature = "async", feature(async_fn_in_trait))]
 #![allow(incomplete_features)]
 
-extern crate alloc;
-
 use heapless::Vec;
 
 pub mod radio;

--- a/device/src/mac/mod.rs
+++ b/device/src/mac/mod.rs
@@ -1,0 +1,178 @@
+use crate::{
+    radio::RadioBuffer, region, state_machines::Downlink, FcntDown, FcntUp, SendData, SessionKeys,
+};
+use generic_array::{typenum::U256, GenericArray};
+use heapless::Vec;
+use lorawan::{
+    self,
+    creator::DataPayloadCreator,
+    keys::CryptoFactory,
+    maccommands::SerializableMacCommand,
+    parser::{parse_with_factory as lorawan_parse, *},
+};
+pub(crate) mod types;
+pub(crate) mod uplink;
+
+#[derive(Debug, Default)]
+pub struct Mac {
+    uplink: uplink::Uplink,
+    pub(crate) downlink: Option<Downlink>,
+    fcnt_up: u32,
+    fcnt_down: u32,
+    confirmed: bool,
+}
+
+#[derive(Debug)]
+pub enum Response {
+    NoAck,
+    SessionExpired,
+    DownlinkReceived(FcntDown),
+    ReadyToSend,
+}
+
+impl From<Response> for crate::Response {
+    fn from(r: Response) -> Self {
+        match r {
+            Response::SessionExpired => crate::Response::SessionExpired,
+            Response::DownlinkReceived(fcnt) => crate::Response::DownlinkReceived(fcnt),
+            Response::NoAck => crate::Response::NoUpdate,
+            Response::ReadyToSend => crate::Response::ReadyToSend,
+        }
+    }
+}
+
+impl Mac {
+    pub(crate) fn handle_rx<C: CryptoFactory + Default>(
+        &mut self,
+        session: &SessionKeys,
+        region: &mut region::Configuration,
+        rx: &mut [u8],
+    ) -> Option<Response> {
+        if let Ok(PhyPayload::Data(DataPayload::Encrypted(encrypted_data))) =
+            lorawan_parse(rx, C::default())
+        {
+            if session.devaddr() == &encrypted_data.fhdr().dev_addr() {
+                let fcnt = encrypted_data.fhdr().fcnt() as u32;
+                let confirmed = encrypted_data.is_confirmed();
+                if encrypted_data.validate_mic(session.newskey(), fcnt)
+                    && (fcnt > self.fcnt_down || fcnt == 0)
+                {
+                    self.fcnt_down = fcnt;
+                    // increment the FcntUp since we have received
+                    // downlink - only reason to not increment
+                    // is if confirmed frame is sent and no
+                    // confirmation (ie: downlink) occurs
+                    self.fcnt_up += 1;
+
+                    let mut copy = Vec::new();
+                    copy.extend_from_slice(encrypted_data.as_bytes()).unwrap();
+
+                    // there two unwraps that are sane in their own right
+                    // * making a new EncryptedDataPayload with owned bytes will
+                    //   always work when copy bytes from another
+                    //   EncryptedPayload
+                    // * the decrypt will always work when we have verified MIC
+                    //   previously
+                    let decrypted = EncryptedDataPayload::new_with_factory(copy, C::default())
+                        .unwrap()
+                        .decrypt(Some(session.newskey()), Some(session.appskey()), self.fcnt_down)
+                        .unwrap();
+
+                    self.uplink.handle_downlink_macs(region, &mut decrypted.fhdr().fopts());
+                    if confirmed {
+                        self.uplink.set_downlink_confirmation();
+                    }
+
+                    if let Ok(FRMPayload::MACCommands(mac_cmds)) = decrypted.frm_payload() {
+                        self.uplink.handle_downlink_macs(region, &mut mac_cmds.mac_commands());
+                    }
+
+                    self.downlink = Some(Downlink::Data(decrypted));
+
+                    // check if FCnt is used up
+                    return if self.fcnt_up == (0xFFFF + 1) {
+                        // signal that the session is expired
+                        // client must know to check for potential data
+                        // (FCnt may be extracted when client checks)
+                        Some(Response::SessionExpired)
+                    } else {
+                        Some(Response::DownlinkReceived(fcnt))
+                    };
+                }
+            }
+        }
+        None
+    }
+    pub(crate) fn rx2_elapsed(&mut self) -> Response {
+        if !self.confirmed {
+            // if this was not a confirmed frame, we can still
+            // increment the FCnt Up
+            self.fcnt_up += 1;
+        }
+
+        if self.confirmed {
+            Response::NoAck
+        } else if self.fcnt_up == (0xFFFF + 1) {
+            // signal that the session is expired
+            // client must know to check for potential data
+            Response::SessionExpired
+        } else {
+            Response::ReadyToSend
+        }
+    }
+
+    #[allow(clippy::match_wild_err_arm)]
+    pub(crate) fn prepare_buffer<C: CryptoFactory + Default, const N: usize>(
+        &mut self,
+        session: &SessionKeys,
+        data: &SendData,
+        tx_buffer: &mut RadioBuffer<N>,
+    ) -> FcntUp {
+        let fcnt = self.fcnt_up;
+        let mut phy: DataPayloadCreator<GenericArray<u8, U256>, C> = DataPayloadCreator::default();
+
+        let mut fctrl = FCtrl(0x0, true);
+        if self.uplink.confirms_downlink() {
+            fctrl.set_ack();
+            self.uplink.clear_downlink_confirmation();
+        }
+
+        self.confirmed = data.confirmed;
+
+        phy.set_confirmed(data.confirmed)
+            .set_fctrl(&fctrl)
+            .set_f_port(data.fport)
+            .set_dev_addr(*session.devaddr())
+            .set_fcnt(fcnt);
+
+        let mut cmds = Vec::new();
+        self.uplink.get_cmds(&mut cmds);
+        let mut dyn_cmds: Vec<&dyn SerializableMacCommand, 8> = Vec::new();
+
+        for cmd in &cmds {
+            if let Err(_e) = dyn_cmds.push(cmd) {
+                panic!("dyn_cmds too small compared to cmds")
+            }
+        }
+
+        match phy.build(data.data, dyn_cmds.as_slice(), session.newskey(), session.appskey()) {
+            Ok(packet) => {
+                tx_buffer.clear();
+                tx_buffer.extend_from_slice(packet).unwrap();
+            }
+            Err(e) => panic!("Error assembling packet! {} ", e),
+        }
+        fcnt
+    }
+
+    pub fn fcnt_up(&self) -> u32 {
+        self.fcnt_up
+    }
+}
+
+pub fn del_to_delay_ms(del: u8) -> u32 {
+    match del {
+        2..=15 => del as u32 * 1000,
+        _ => region::constants::RECEIVE_DELAY1,
+    }
+}

--- a/device/src/mac/mod.rs
+++ b/device/src/mac/mod.rs
@@ -103,6 +103,7 @@ impl Mac {
         }
         None
     }
+
     pub(crate) fn rx2_elapsed(&mut self) -> Response {
         if !self.confirmed {
             // if this was not a confirmed frame, we can still

--- a/device/src/mac/uplink.rs
+++ b/device/src/mac/uplink.rs
@@ -3,13 +3,13 @@ This a temporary design where flags will be left about desired MAC uplinks by th
 During Uplink assembly, this struct will be inquired to drive construction
  */
 
+use super::del_to_delay_ms;
+use crate::region;
 use heapless::Vec;
-
-use super::region;
 use lorawan::maccommands::{LinkADRAnsPayload, MacCommand, RXTimingSetupAnsPayload};
 
 #[derive(Default, Debug)]
-pub struct Mac {
+pub struct Uplink {
     adr_ans: AdrAns,
     rx_delay_ans: RxDelayAns,
     confirmed: bool,
@@ -57,22 +57,15 @@ impl MacAnsTrait for RxDelayAns {
     }
 }
 
-pub fn del_to_delay_ms(del: u8) -> u32 {
-    match del {
-        2..=15 => del as u32 * 1000,
-        _ => region::constants::RECEIVE_DELAY1,
-    }
-}
-
-impl Mac {
-    pub fn set_confirmed(&mut self) {
+impl Uplink {
+    pub fn set_downlink_confirmation(&mut self) {
         self.confirmed = true;
     }
 
-    pub fn clear_confirmed(&mut self) {
+    pub fn clear_downlink_confirmation(&mut self) {
         self.confirmed = false;
     }
-    pub fn is_confirmed(&self) -> bool {
+    pub fn confirms_downlink(&self) -> bool {
         self.confirmed
     }
 

--- a/device/src/state_machines/mod.rs
+++ b/device/src/state_machines/mod.rs
@@ -20,7 +20,8 @@ pub struct Shared<R: radio::PhyRxTx + Timings, RNG: RngCore, const N: usize> {
 }
 
 #[allow(clippy::large_enum_variant)]
-enum Downlink {
+#[derive(Debug)]
+pub(crate) enum Downlink {
     Data(DecryptedDataPayload<Vec<u8, 256>>),
     Join,
 }
@@ -40,7 +41,7 @@ impl<R: radio::PhyRxTx + Timings, RNG: RngCore, const N: usize> Shared<R, RNG, N
     }
 
     pub fn take_data_downlink(&mut self) -> Option<DecryptedDataPayload<Vec<u8, 256>>> {
-        if let Some(Downlink::Data(payload)) = self.downlink.take() {
+        if let Some(Downlink::Data(payload)) = self.mac.downlink.take() {
             Some(payload)
         } else {
             None

--- a/device/src/state_machines/no_session.rs
+++ b/device/src/state_machines/no_session.rs
@@ -7,9 +7,8 @@ use super::{
 };
 use lorawan::{
     self,
-    keys::AES128,
     parser::parse_with_factory as lorawan_parse,
-    parser::{DecryptedJoinAcceptPayload, DevAddr, JoinAcceptPayload, PhyPayload},
+    parser::{JoinAcceptPayload, PhyPayload},
 };
 
 pub enum NoSession {
@@ -89,9 +88,9 @@ pub enum Error {
     NewSessionWhileWaitingForJoinResponse,
 }
 
-impl<R> From<Error> for super::super::Error<R> {
-    fn from(error: Error) -> super::super::Error<R> {
-        super::super::Error::NoSession(error)
+impl<R> From<Error> for super::Error<R> {
+    fn from(error: Error) -> super::Error<R> {
+        super::Error::NoSession(error)
     }
 }
 
@@ -349,13 +348,13 @@ impl WaitingForJoinResponse {
                                         shared.region.process_join_accept(&decrypt);
                                         shared.downlink = Some(super::Downlink::Join);
                                         if decrypt.validate_mic(credentials.appkey()) {
-                                            let session = SessionData::derive_new(
+                                            let session = SessionKeys::derive_new(
                                                 &decrypt,
                                                 self.devnonce,
                                                 credentials,
                                             );
                                             return (
-                                                Session::new(session).into(),
+                                                Session::new(session, shared.region.clone()).into(),
                                                 Ok(Response::JoinSuccess),
                                             );
                                         }
@@ -416,57 +415,5 @@ impl WaitingForJoinResponse {
 impl From<WaitingForJoinResponse> for Idle {
     fn from(val: WaitingForJoinResponse) -> Idle {
         Idle { join_attempts: val.join_attempts }
-    }
-}
-
-pub struct SessionData {
-    newskey: AES128,
-    appskey: AES128,
-    devaddr: DevAddr<[u8; 4]>,
-    fcnt_up: u32,
-    pub fcnt_down: u32,
-}
-
-impl SessionData {
-    pub fn derive_new<T: core::convert::AsRef<[u8]>, F: lorawan::keys::CryptoFactory>(
-        decrypt: &DecryptedJoinAcceptPayload<T, F>,
-        devnonce: DevNonce,
-        credentials: &Credentials,
-    ) -> SessionData {
-        Self::new(
-            decrypt.derive_newskey(&devnonce, credentials.appkey()),
-            decrypt.derive_appskey(&devnonce, credentials.appkey()),
-            DevAddr::new([
-                decrypt.dev_addr().as_ref()[0],
-                decrypt.dev_addr().as_ref()[1],
-                decrypt.dev_addr().as_ref()[2],
-                decrypt.dev_addr().as_ref()[3],
-            ])
-            .unwrap(),
-        )
-    }
-
-    pub fn new(newskey: AES128, appskey: AES128, devaddr: DevAddr<[u8; 4]>) -> SessionData {
-        SessionData { newskey, appskey, devaddr, fcnt_up: 0, fcnt_down: 0 }
-    }
-
-    pub fn newskey(&self) -> &AES128 {
-        &self.newskey
-    }
-
-    pub fn appskey(&self) -> &AES128 {
-        &self.appskey
-    }
-
-    pub fn devaddr(&self) -> &DevAddr<[u8; 4]> {
-        &self.devaddr
-    }
-
-    pub fn fcnt_up(&self) -> u32 {
-        self.fcnt_up
-    }
-
-    pub fn fcnt_up_increment(&mut self) {
-        self.fcnt_up += 1;
     }
 }

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -924,6 +924,7 @@ fixed_len_struct! {
 
 fixed_len_struct! {
     /// DevAddr represents a 32 bit device address.
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     struct DevAddr[4];
 }
 
@@ -934,6 +935,16 @@ impl<T: AsRef<[u8]>> DevAddr<T> {
     }
     pub fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl From<DevAddr<[u8; 4]>> for u32 {
+    fn from(v: DevAddr<[u8; 4]>) -> Self {
+        let bytes = v.as_ref();
+        u32::from(bytes[0]) << 24
+            | u32::from(bytes[1]) << 16
+            | u32::from(bytes[2]) << 8
+            | u32::from(bytes[3])
     }
 }
 


### PR DESCRIPTION
This is the first stage in some refactoring that I am doing to try to unify the async and no_async (state_machine) device implementations. 

I've minimized impact on the async_device area of the code to try to keep things simple. However, I believe that this should allow us to move more non-runtime logic into the `mac` module and to share more of the protocol logic amongst the two runtimes.

I ran into this as I was working on a solution for #117 and I realized it would be a lot easier to start consolidating some of the duplicate code.

EDIT: to be clear, I think this refactor starts to make it easier to share the [logic here](https://github.com/ivajloip/rust-lorawan/blob/7f7ceef024991d0f068b59cff715897b021e8521/device/src/async_device/mod.rs#L311-L360).