### PR TITLE
async_device: rx config decoupling & sleep

### DIFF
--- a/device/src/async_device/lora_radio.rs
+++ b/device/src/async_device/lora_radio.rs
@@ -21,7 +21,7 @@ where
     DLY: DelayUs,
 {
     pub fn new(lora: LoRa<RK, DLY>) -> Self {
-        Self { lora, rx_pkt_params: None,}
+        Self { lora, rx_pkt_params: None }
     }
 }
 

--- a/device/src/async_device/radio.rs
+++ b/device/src/async_device/radio.rs
@@ -36,9 +36,13 @@ pub trait PhyRxTx: Sized {
     /// Configures the radio to receive data. This future should not actually await the data itself.
     async fn setup_rx(&mut self, config: RfConfig) -> Result<(), Self::PhyError>;
 
-
     /// Receive data into the provided buffer with the given transceiver configuration. The returned
     /// future should only complete when RX data have been received. Furthermore, it should be
     /// possible to await the future again without settings up the receive config again.
     async fn rx(&mut self, rx_buf: &mut [u8]) -> Result<(usize, RxQuality), Self::PhyError>;
+
+    /// Puts the radio into a low-power mode
+    async fn low_power(&mut self) -> Result<(), Self::PhyError> {
+        Ok(())
+    }
 }

--- a/device/src/async_device/radio.rs
+++ b/device/src/async_device/radio.rs
@@ -29,15 +29,16 @@ pub trait PhyRxTx: Sized {
     #[cfg(not(feature = "defmt"))]
     type PhyError;
 
-    /// Transmit data buffer with the given tranciever configuration. The returned future
+    /// Transmit data buffer with the given transceiver configuration. The returned future
     /// should only complete once data have been transmitted.
     async fn tx(&mut self, config: TxConfig, buf: &[u8]) -> Result<u32, Self::PhyError>;
 
-    /// Receive data into the provided buffer with the given tranciever configuration. The returned
-    /// future should only complete when RX data have been received.
-    async fn rx(
-        &mut self,
-        config: RfConfig,
-        rx_buf: &mut [u8],
-    ) -> Result<(usize, RxQuality), Self::PhyError>;
+    /// Configures the radio to receive data. This future should not actually await the data itself.
+    async fn setup_rx(&mut self, config: RfConfig) -> Result<(), Self::PhyError>;
+
+
+    /// Receive data into the provided buffer with the given transceiver configuration. The returned
+    /// future should only complete when RX data have been received. Furthermore, it should be
+    /// possible to await the future again without settings up the receive config again.
+    async fn rx(&mut self, rx_buf: &mut [u8]) -> Result<(usize, RxQuality), Self::PhyError>;
 }

--- a/device/src/async_device/test/mod.rs
+++ b/device/src/async_device/test/mod.rs
@@ -70,7 +70,7 @@ async fn test_join_rx2() {
     radio.handle_rxtx(handle_join_request);
 
     // Await the device to return and verify state
-    if let Ok(()) = async_device.await.unwrap() {
+    if async_device.await.unwrap().is_ok() {
         assert_eq!(4, timer.get_armed_count().await);
     } else {
         assert!(false);

--- a/device/src/async_device/test/radio.rs
+++ b/device/src/async_device/test/radio.rs
@@ -11,7 +11,10 @@ impl TestRadio {
     pub fn new() -> (RadioChannel, Self) {
         let (tx, rx) = mpsc::channel(1);
         let last_uplink = Arc::new(Mutex::new(None));
-        (RadioChannel { tx, last_uplink: last_uplink.clone() }, Self { rx, last_uplink, current_config: None })
+        (
+            RadioChannel { tx, last_uplink: last_uplink.clone() },
+            Self { rx, last_uplink, current_config: None },
+        )
     }
 }
 

--- a/device/src/async_device/test/radio.rs
+++ b/device/src/async_device/test/radio.rs
@@ -7,6 +7,7 @@ use tokio::{
     time,
 };
 type RxTxHandler = fn(Option<Uplink>, RfConfig, &mut [u8]) -> usize;
+
 impl TestRadio {
     pub fn new() -> (RadioChannel, Self) {
         let (tx, rx) = mpsc::channel(1);

--- a/device/src/async_device/test/timer.rs
+++ b/device/src/async_device/test/timer.rs
@@ -1,6 +1,7 @@
 use crate::async_device::radio::Timer;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
+
 impl TestTimer {
     pub fn new() -> (TimerChannel, Self) {
         let (tx, rx) = mpsc::channel(5);

--- a/device/src/radio/types.rs
+++ b/device/src/radio/types.rs
@@ -1,6 +1,6 @@
 use super::*;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RfConfig {
     pub frequency: u32,
     pub bandwidth: Bandwidth,
@@ -9,14 +9,14 @@ pub struct RfConfig {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TxConfig {
     pub pw: i8,
     pub rf: RfConfig,
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RxQuality {
     rssi: i16,
     snr: i8,


### PR DESCRIPTION
I was considering solutions to #117 but I wanted to do a first "simple" PR to try to make it easier.

First, I decouple configuring the radio to receive with actually waiting for the radio to receive. This will make it easier to configure the radio once and receive many packets (this will also be important for Class C behavior).

Since I was in this area of the code, I've "bundled" the logic with adding some sleeps. This will also help with class C behavior as instead of "sleeping", an RXC window will be opened.