### PR TITLE
loosen up dependencies

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -14,13 +14,12 @@ description = "A Rust LoRaWAN device stack implementation"
 
 [dependencies]
 lorawan = { version = "0.7.3", path = "../encoding", default-features = false }
-heapless = "0.7.5"
-as-slice = "0.2"
+heapless = "0.7"
 generic-array = "0.14.2"
-defmt = { version = "0.3.0", optional = true }
-futures = { version = "0.3.17", default-features = false, optional = true }
-rand_core = { version = "0.6.2", default-features = false }
-serde = { version = "1.0.145", default-features = false, features = ["derive"], optional = true}
+defmt = { version = "0.3", optional = true }
+futures = { version = "0.3", default-features = false, optional = true }
+rand_core = { version = "0.6", default-features = false }
+serde = { version = "1", default-features = false, features = ["derive"], optional = true}
 lora-phy = { version = "1", optional = true }
 
 [features]

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 [dependencies]
 aes = { version = "0.6.0", optional = true }
 cmac = { version = "0.5.1", optional = true }
-generic-array = "0.14.4"
-defmt = { version = "0.3.0", optional = true }
-serde = { version = "1.0.145", default-features = false, features = ["derive"], optional = true}
+generic-array = "0.14"
+defmt = { version = "0.3", optional = true }
+serde = { version = "1", default-features = false, features = ["derive"], optional = true}
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0"
 trallocator = { path = "./trallocator" }
 
 [[bench]]


### PR DESCRIPTION
A few of these dependencies seem unnecessarily constrained to point-releases. They have been loosened.

Also it seeme dlike as-slice was an unnecessary dependency in the device toml.