### PR TITLE
Async Tests

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -23,6 +23,11 @@ rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true}
 lora-phy = { version = ">=2.1.1", optional = true }
 
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros", "time", "sync"]}
+rand = { version = "0", features = ["getrandom"] }
+lorawan = { version = "0.7.3", path = "../encoding", features = ["default-crypto"] }
+
 [features]
 defmt = ["dep:defmt", "lorawan/defmt", "lora-modulation/defmt"]
 default = []

--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -26,6 +26,9 @@ use crate::{private::Sealed, radio::types::RadioBuffer, GetRng};
 pub mod lora_radio;
 pub mod radio;
 
+#[cfg(test)]
+mod test;
+
 use core::cmp::min;
 
 /// Type-level version of the [`None`] variant
@@ -101,6 +104,7 @@ where
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug)]
 pub enum Error<R> {
     Radio(R),
     NetworkNotJoined,
@@ -177,6 +181,14 @@ where
 
     pub fn get_region(&mut self) -> &region::Configuration {
         &self.region
+    }
+
+    pub fn get_radio(&mut self) -> &R {
+        &self.phy.radio
+    }
+
+    pub fn get_mut_radio(&mut self) -> &mut R {
+        &mut self.phy.radio
     }
 
     /// Retrieve the current data rate being used by this device.

--- a/device/src/async_device/test/mod.rs
+++ b/device/src/async_device/test/mod.rs
@@ -1,0 +1,142 @@
+use super::*;
+use crate::radio::{RfConfig, RxQuality, TxConfig};
+use crate::region;
+use lorawan::default_crypto::DefaultFactory;
+
+mod timer;
+use timer::{TestTimer, TimerChannel};
+
+mod radio;
+use radio::{RadioChannel, TestRadio, Uplink};
+
+type Device =
+    crate::async_device::Device<TestRadio, DefaultFactory, TestTimer, rand_core::OsRng, 512>;
+
+pub fn get_key() -> [u8; 16] {
+    [0; 16]
+}
+pub fn get_credentials() -> JoinMode {
+    JoinMode::OTAA { deveui: [0; 8], appeui: [0; 8], appkey: get_key() }
+}
+
+fn setup() -> (RadioChannel, TimerChannel, Device) {
+    let (radio_channel, mock_radio) = TestRadio::new();
+    let (timer_channel, mock_timer) = TestTimer::new();
+    let region = region::US915::default();
+    let async_device: crate::async_device::Device<
+        TestRadio,
+        DefaultFactory,
+        TestTimer,
+        rand_core::OsRng,
+        512,
+    > = Device::new(region.into(), mock_radio, mock_timer, rand::rngs::OsRng);
+    (radio_channel, timer_channel, async_device)
+}
+
+#[tokio::test]
+async fn test_join_rx1() {
+    let (radio, timer, mut async_device) = setup();
+    // Run the device
+    let async_device = tokio::spawn(async move { async_device.join(&get_credentials()).await });
+
+    // Trigger beginning of RX1
+    timer.fire().await;
+    // Trigger handling of JoinAccept
+    radio.handle_rxtx(handle_join_request);
+
+    // Await the device to return and verify state
+    if let Ok(()) = async_device.await.unwrap() {
+        // NB: timer is armed twice (even if not fired twice)
+        // because RX1 end is armed when packet is received
+        assert_eq!(2, timer.get_armed_count().await);
+    } else {
+        assert!(false);
+    }
+}
+
+#[tokio::test]
+async fn test_join_rx2() {
+    let (radio, timer, mut async_device) = setup();
+    // Run the device
+    let async_device = tokio::spawn(async move { async_device.join(&get_credentials()).await });
+
+    // Trigger beginning of RX1
+    timer.fire().await;
+    // Trigger end of RX1
+    timer.fire().await;
+    // Trigger start of RX2
+    timer.fire().await;
+    // Pass the join request handler
+    radio.handle_rxtx(handle_join_request);
+
+    // Await the device to return and verify state
+    if let Ok(()) = async_device.await.unwrap() {
+        assert_eq!(4, timer.get_armed_count().await);
+    } else {
+        assert!(false);
+    }
+}
+
+#[tokio::test]
+async fn test_no_join_accept() {
+    let (_radio, timer, mut async_device) = setup();
+    // Run the device
+    let async_device = tokio::spawn(async move { async_device.join(&get_credentials()).await });
+
+    // Trigger beginning of RX1
+    timer.fire().await;
+    // Trigger end of RX1
+    timer.fire().await;
+    // Trigger start of RX2
+    timer.fire().await;
+    // Trigger end of RX2
+    timer.fire().await;
+
+    // Await the device to return and verify state
+    if let Err(Error::RxTimeout) = async_device.await.unwrap() {
+        assert_eq!(4, timer.get_armed_count().await);
+    } else {
+        assert!(false);
+    }
+}
+
+#[tokio::test]
+async fn test_noise() {
+    let (radio, timer, mut async_device) = setup();
+    // Run the device
+    let async_device = tokio::spawn(async move { async_device.join(&get_credentials()).await });
+    // Trigger beginning of RX1
+    timer.fire().await;
+    // Send an invalid lorawan frame. 0 length is enough to confuse it
+    radio.handle_rxtx(|_, _, _| 0);
+
+    // Await the device to return and verify state
+    if let Err(Error::UnableToDecodePayload(_)) = async_device.await.unwrap() {
+        assert!(true);
+    } else {
+        assert!(false);
+    }
+}
+
+/// Handle join request and pack a JoinAccept into RxBuffer
+fn handle_join_request(uplink: Option<Uplink>, _config: RfConfig, rx_buffer: &mut [u8]) -> usize {
+    //TODO: Verify the JoinRequest is ok
+    if let Some(mut uplink) = uplink {
+        if let PhyPayload::JoinRequest(_) = uplink.get_payload() {
+            let mut buffer: [u8; 17] = [0; 17];
+            let mut phy = lorawan::creator::JoinAcceptCreator::with_options(
+                &mut buffer,
+                DefaultFactory::default(),
+            )
+            .unwrap();
+            let app_nonce_bytes = [1; 3];
+            phy.set_app_nonce(&app_nonce_bytes);
+            phy.set_net_id(&[1; 3]);
+            phy.set_dev_addr(&[1; 4]);
+            phy.build(&AES128(get_key())).unwrap();
+            buffer.iter().zip(rx_buffer).for_each(|(a, b)| *b = *a);
+            return 17;
+        }
+    }
+    0
+}

--- a/device/src/async_device/test/radio.rs
+++ b/device/src/async_device/test/radio.rs
@@ -1,0 +1,96 @@
+use super::*;
+use crate::async_device::radio::PhyRxTx;
+use std::sync::Arc;
+use std::vec::Vec;
+use tokio::{
+    sync::{mpsc, Mutex},
+    time,
+};
+type RxTxHandler = fn(Option<Uplink>, RfConfig, &mut [u8]) -> usize;
+impl TestRadio {
+    pub fn new() -> (RadioChannel, Self) {
+        let (tx, rx) = mpsc::channel(1);
+        let last_uplink = Arc::new(Mutex::new(None));
+        (RadioChannel { tx, last_uplink: last_uplink.clone() }, Self { rx, last_uplink })
+    }
+}
+
+pub struct TestRadio {
+    last_uplink: Arc<Mutex<Option<Uplink>>>,
+    rx: mpsc::Receiver<RxTxHandler>,
+}
+
+pub struct Uplink {
+    data: Vec<u8>,
+    #[allow(unused)]
+    tx_config: TxConfig,
+}
+
+impl Uplink {
+    /// Creates a copy from a reference and ensures the packet is at least parseable.
+    fn new(data_in: &[u8], tx_config: TxConfig) -> Result<Self, &'static str> {
+        let mut data: Vec<u8> = Vec::new();
+        data.extend_from_slice(data_in);
+        let _parse = parse(data.as_mut_slice())?;
+        Ok(Self { data, tx_config: tx_config })
+    }
+
+    pub fn get_payload(&mut self) -> PhyPayload<&mut [u8], DefaultFactory> {
+        // unwrap since we verified parse in new
+        parse(self.data.as_mut_slice()).unwrap()
+    }
+}
+
+impl PhyRxTx for TestRadio {
+    type PhyError = &'static str;
+
+    async fn tx(&mut self, config: TxConfig, buffer: &[u8]) -> Result<u32, Self::PhyError> {
+        let length = buffer.len();
+        // stash the uplink, to be consumed by channel or by rx handler
+        let mut last_uplink = self.last_uplink.lock().await;
+        // ensure that we have always consumed the previous uplink
+        if last_uplink.is_some() {
+            return Err("Radio already has an uplink");
+        }
+        *last_uplink = Some(Uplink::new(&buffer, config)?);
+        Ok(length as u32)
+    }
+
+    async fn rx(
+        &mut self,
+        config: RfConfig,
+        receiving_buffer: &mut [u8],
+    ) -> Result<(usize, RxQuality), Self::PhyError> {
+        let handler = self.rx.recv().await.unwrap();
+        let mut last_uplink = self.last_uplink.lock().await;
+        // a quick yield to let timer arm
+        time::sleep(time::Duration::from_millis(50)).await;
+        let size = handler(last_uplink.take(), config, receiving_buffer);
+        Ok((size, RxQuality::new(0, 0)))
+    }
+}
+
+impl Timings for TestRadio {
+    fn get_rx_window_offset_ms(&self) -> i32 {
+        0
+    }
+    fn get_rx_window_duration_ms(&self) -> u32 {
+        100
+    }
+}
+
+/// A channel for the test fixture to trigger fires and to check calls.
+pub struct RadioChannel {
+    #[allow(unused)]
+    last_uplink: Arc<Mutex<Option<Uplink>>>,
+    tx: mpsc::Sender<RxTxHandler>,
+}
+
+impl RadioChannel {
+    pub fn handle_rxtx(&self, handler: RxTxHandler) {
+        let tx = self.tx.clone();
+        tokio::spawn(async move {
+            tx.send(handler).await.unwrap();
+        });
+    }
+}

--- a/device/src/async_device/test/timer.rs
+++ b/device/src/async_device/test/timer.rs
@@ -1,0 +1,49 @@
+use crate::async_device::radio::Timer;
+use std::sync::Arc;
+use tokio::sync::{mpsc, Mutex};
+impl TestTimer {
+    pub fn new() -> (TimerChannel, Self) {
+        let (tx, rx) = mpsc::channel(5);
+        let armed_count = Arc::new(Mutex::new(0));
+        (TimerChannel { tx, armed_count: armed_count.clone() }, Self { rx, armed_count })
+    }
+}
+
+pub struct TestTimer {
+    armed_count: Arc<Mutex<usize>>,
+    rx: mpsc::Receiver<()>,
+}
+
+impl Timer for TestTimer {
+    fn reset(&mut self) {}
+
+    async fn at(&mut self, _millis: u64) {
+        {
+            *self.armed_count.lock().await += 1;
+        }
+        self.rx.recv().await;
+    }
+
+    async fn delay_ms(&mut self, _millis: u64) {
+        {
+            *self.armed_count.lock().await += 1;
+        }
+        self.rx.recv().await;
+    }
+}
+
+/// A channel for the test fixture to trigger fires and to check calls.
+pub struct TimerChannel {
+    armed_count: Arc<Mutex<usize>>,
+    tx: mpsc::Sender<()>,
+}
+
+impl TimerChannel {
+    pub async fn fire(&self) {
+        self.tx.send(()).await.unwrap();
+    }
+
+    pub async fn get_armed_count(&self) -> usize {
+        *self.armed_count.lock().await
+    }
+}

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "async", feature(async_fn_in_trait))]
 #![allow(incomplete_features)]
 

--- a/encoding/src/creator.rs
+++ b/encoding/src/creator.rs
@@ -48,12 +48,10 @@ pub struct JoinAcceptCreator<D, F> {
 impl<D: AsMut<[u8]>, F: CryptoFactory + Default> JoinAcceptCreator<D, F> {
     /// Creates a well initialized JoinAcceptCreator with specific data and crypto functions.
     ///
-    /// TODO: Add more detials & and example
+    /// TODO: Add more details & and example
     pub fn with_options<'a>(mut data: D, factory: F) -> Result<Self, &'a str> {
+        // length verification will occur during building
         let d = data.as_mut();
-        if d.len() < 33 {
-            return Err("data slice is too short");
-        }
         d[0] = 0x20;
         Ok(Self { data, with_c_f_list: false, encrypted: false, factory })
     }
@@ -139,7 +137,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> JoinAcceptCreator<D, F> {
     ) -> Result<&mut Self, &str> {
         let ch_list = list.as_ref();
         if ch_list.len() > 5 {
-            return Err("too many frequences");
+            return Err("too many frequencies");
         }
         let d = self.data.as_mut();
         ch_list.iter().enumerate().for_each(|(i, fr)| {
@@ -159,6 +157,14 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> JoinAcceptCreator<D, F> {
     ///
     /// * key - the key to be used for encryption and setting the MIC.
     pub fn build(&mut self, key: &keys::AES128) -> Result<&[u8], &str> {
+        let required_len = if self.with_c_f_list {
+            33
+        } else {
+            17
+        };
+        if self.data.as_mut().len() < required_len {
+            return Err("data slice is too short");
+        }
         if !self.encrypted {
             self.encrypt_payload(key);
         }


### PR DESCRIPTION
I've put together some tests around the async runtime so that we may proceed with #119 with more confidence.

The tests:
* demonstrate RX1 and RX2 joining (which more or less demonstrates that RX1 and RX2 works for data due to how @lulf architected the code)
* RX timeout when no RF is received
* the issue from #119 where a single noisy frame breaks things.

While implementing JoinAccept for the tests, I inadvertently uncovered a bug with the JoinAcceptCreator which made it not tolerate building a JoinAccept without a CFList. I implemented a small patch to the issue which makes it tolerate empty CFList or full Type 1 CFList. I think it still needs to tolerate partial Type 1 CFList and I'm unclear whether it tolerates Type 2 CFList packing, but that seemed out of scope for now and can be addressed in a future PR.