### PR TITLE
make lora-modulation no_std

### DIFF
--- a/modulation/Cargo.toml
+++ b/modulation/Cargo.toml
@@ -14,8 +14,6 @@ defmt = { version = "0", optional = true }
 # this is only temporary in hopes that lora-phy adopts this crate as a dependency
 lora-phy = { version = "1", optional = true }
 
-
 [features]
 defmt = ["dep:defmt"]
 external-lora-phy = ["dep:lora-phy"]
-

--- a/modulation/src/lib.rs
+++ b/modulation/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// Channel width.


### PR DESCRIPTION
Forgot to put the no_std flag on lora-modulation. Took the opportunity to clean up spaces in the toml file.