### PR TITLE
lora-modulation release 0.1.2

### DIFF
--- a/modulation/Cargo.toml
+++ b/modulation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lora-modulation"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Louis Thiery <thiery.louis@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
The no_std tag was confirmed to fix [the issue](https://github.com/embassy-rs/lora-phy/pull/26#issuecomment-1715892151) so cutting another release.