### PR TITLE
set all crates to rust edition 2021. set workspace resolver to "2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "encoding",
     "modulation",
 ]
+resolver = "2"
 
 [profile.dev]
 opt-level = "s"

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lorawan-device"
 version = "0.10.0"
 authors = ["Louis Thiery <thiery.louis@gmail.com>", "Ulf Lilleengen <lulf@redhat.com>"]
-edition = "2018"
+edition = "2021"
 categories = [
     "embedded",
     "hardware-support",

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lorawan"
 version = "0.7.3"
-edition = "2018"
+edition = "2021"
 authors = ["Ivaylo Petrov <ivajloip@gmail.com>"]
 description = "Crate lorawan provides structures and tools for reading and writing LoRaWAN messages from and to a slice of bytes."
 repository = "https://github.com/ivajloip/rust-lorawan"


### PR DESCRIPTION
I was getting a compilation warning:
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

Not too sure what the risks are but I figured I just set everything to most recent. At any rate, the warning is resolved.