### PR TITLE
Expand on device unit tests

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lorawan-device"
 version = "0.10.0"
-authors = ["Louis Thiery <louis@helium.com>", "Ulf Lilleengen <lulf@redhat.com>"]
+authors = ["Louis Thiery <thiery.louis@gmail.com>", "Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2018"
 categories = [
     "embedded",

--- a/device/src/async_device/test/radio.rs
+++ b/device/src/async_device/test/radio.rs
@@ -1,13 +1,10 @@
 use super::*;
 use crate::async_device::radio::PhyRxTx;
 use std::sync::Arc;
-use std::vec::Vec;
 use tokio::{
     sync::{mpsc, Mutex},
     time,
 };
-type RxTxHandler = fn(Option<Uplink>, RfConfig, &mut [u8]) -> usize;
-
 impl TestRadio {
     pub fn new() -> (RadioChannel, Self) {
         let (tx, rx) = mpsc::channel(1);
@@ -23,27 +20,6 @@ pub struct TestRadio {
     current_config: Option<RfConfig>,
     last_uplink: Arc<Mutex<Option<Uplink>>>,
     rx: mpsc::Receiver<RxTxHandler>,
-}
-
-pub struct Uplink {
-    data: Vec<u8>,
-    #[allow(unused)]
-    tx_config: TxConfig,
-}
-
-impl Uplink {
-    /// Creates a copy from a reference and ensures the packet is at least parseable.
-    fn new(data_in: &[u8], tx_config: TxConfig) -> Result<Self, &'static str> {
-        let mut data: Vec<u8> = Vec::new();
-        data.extend_from_slice(data_in);
-        let _parse = parse(data.as_mut_slice())?;
-        Ok(Self { data, tx_config: tx_config })
-    }
-
-    pub fn get_payload(&mut self) -> PhyPayload<&mut [u8], DefaultFactory> {
-        // unwrap since we verified parse in new
-        parse(self.data.as_mut_slice()).unwrap()
-    }
 }
 
 impl PhyRxTx for TestRadio {

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -13,6 +13,9 @@ use mac::Mac;
 pub mod region;
 pub use region::Region;
 
+#[cfg(test)]
+mod test_util;
+
 mod state_machines;
 use core::marker::PhantomData;
 use lorawan::{

--- a/device/src/mac/mod.rs
+++ b/device/src/mac/mod.rs
@@ -35,7 +35,7 @@ impl From<Response> for crate::Response {
         match r {
             Response::SessionExpired => crate::Response::SessionExpired,
             Response::DownlinkReceived(fcnt) => crate::Response::DownlinkReceived(fcnt),
-            Response::NoAck => crate::Response::NoUpdate,
+            Response::NoAck => crate::Response::NoAck,
             Response::ReadyToSend => crate::Response::ReadyToSend,
         }
     }

--- a/device/src/state_machines/mod.rs
+++ b/device/src/state_machines/mod.rs
@@ -7,6 +7,9 @@ pub mod session;
 
 pub use region::DR;
 
+#[cfg(test)]
+mod test;
+
 pub struct Shared<R: radio::PhyRxTx + Timings, RNG: RngCore, const N: usize> {
     radio: R,
     credentials: Option<Credentials>,

--- a/device/src/state_machines/no_session.rs
+++ b/device/src/state_machines/no_session.rs
@@ -256,7 +256,7 @@ impl WaitingForRxWindow {
         self,
         event: Event<R>,
         shared: &mut Shared<R, RNG, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R::PhyError>>) {
+    ) -> (SuperState, Result<Response, super::Error<R::PhyError>>) {
         match event {
             // we are waiting for a Timeout
             Event::TimeoutFired => {
@@ -330,7 +330,7 @@ impl WaitingForJoinResponse {
         self,
         event: Event<R>,
         shared: &mut Shared<R, RNG, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R::PhyError>>) {
+    ) -> (SuperState, Result<Response, super::Error<R::PhyError>>) {
         match event {
             // we are waiting for the async tx to complete
             Event::RadioEvent(radio_event) => {

--- a/device/src/state_machines/session.rs
+++ b/device/src/state_machines/session.rs
@@ -140,7 +140,7 @@ impl Session {
         self,
         event: Event<R>,
         shared: &mut Shared<R, RNG, N>,
-    ) -> (SuperState, Result<Response, super::super::Error<R::PhyError>>) {
+    ) -> (SuperState, Result<Response, super::Error<R::PhyError>>) {
         match self {
             Session::Idle(state) => state.handle_event::<R, C, RNG, N>(event, shared),
             Session::SendingData(state) => state.handle_event::<R, C, RNG, N>(event, shared),
@@ -409,7 +409,7 @@ impl WaitingForRx {
                                 &mut self.region,
                                 shared.radio.get_received_packet(),
                             ) {
-                                return (self.into(), Ok(response.into()));
+                                return (self.into_idle().into(), Ok(response.into()));
                             }
                             (self.into(), Ok(Response::NoUpdate))
                         }

--- a/device/src/state_machines/test/mod.rs
+++ b/device/src/state_machines/test/mod.rs
@@ -1,0 +1,121 @@
+use super::*;
+mod util;
+use crate::test_util::*;
+use util::*;
+
+use crate::Event;
+#[test]
+fn test_join_rx1() {
+    let mut device = test_device(get_otaa_credentials());
+    let response = device.handle_event(Event::NewSessionRequest).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(5000)));
+    // send a timeout for beginning of window
+    let response = device.handle_event(Event::TimeoutFired).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(5100)));
+    device.get_radio().set_rxtx_handler(handle_join_request);
+    // send a radio event to let the radio device indicate a packet was received
+    let response = device.handle_event(Event::RadioEvent(radio::Event::PhyEvent(()))).unwrap();
+    assert!(matches!(response, Response::JoinSuccess));
+    assert!(device.get_session_keys().is_some());
+}
+
+#[test]
+fn test_join_rx2() {
+    let mut device = test_device(get_otaa_credentials());
+    device.get_radio().set_rxtx_handler(handle_join_request);
+    let response = device.handle_event(Event::NewSessionRequest).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(5000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(5100)));
+    // send a timeout for end of rx2
+    let response = device.handle_event(Event::TimeoutFired).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(6000)));
+    // send a timeout for beginning of rx2
+    let response = device.handle_event(Event::TimeoutFired).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(6100)));
+    // send a radio event to let the radio device indicate a packet was received
+    let response = device.handle_event(Event::RadioEvent(radio::Event::PhyEvent(()))).unwrap();
+    assert!(matches!(response, Response::JoinSuccess));
+    assert!(device.get_session_keys().is_some());
+}
+
+#[test]
+fn test_unconfirmed_uplink_no_downlink() {
+    let mut device = test_device(get_abp_credentials());
+    let response = device.send(&[0; 1], 1, false).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // being Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx2
+    assert!(matches!(response, Response::ReadyToSend));
+}
+#[test]
+fn test_confirmed_uplink_no_ack() {
+    let mut device = test_device(get_abp_credentials());
+    let response = device.send(&[0; 1], 1, true).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // being Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx2
+    assert!(matches!(response, Response::NoAck));
+}
+
+#[test]
+fn test_confirmed_uplink_with_ack_rx1() {
+    let mut device = test_device(get_abp_credentials());
+    let response = device.send(&[0; 1], 1, true).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    device.get_radio().set_rxtx_handler(handle_data_uplink_with_link_adr_req);
+    // send a radio event to let the radio device indicate a packet was received
+    let response = device.handle_event(Event::RadioEvent(radio::Event::PhyEvent(()))).unwrap();
+    assert!(matches!(response, Response::DownlinkReceived(0)));
+}
+
+#[test]
+fn test_confirmed_uplink_with_ack_rx2() {
+    let mut device = test_device(get_abp_credentials());
+    let response = device.send(&[0; 1], 1, true).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // end Rx1
+    assert!(matches!(response, Response::TimeoutRequest(2000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // being Rx2
+    assert!(matches!(response, Response::TimeoutRequest(2100)));
+    device.get_radio().set_rxtx_handler(handle_data_uplink_with_link_adr_req);
+    // send a radio event to let the radio device indicate a packet was received
+    let response = device.handle_event(Event::RadioEvent(radio::Event::PhyEvent(()))).unwrap();
+    assert!(matches!(response, Response::DownlinkReceived(0)));
+}
+
+#[test]
+fn test_link_adr_ans() {
+    let mut device = test_device(get_abp_credentials());
+    let response = device.send(&[0; 1], 1, true).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    device.get_radio().set_rxtx_handler(handle_data_uplink_with_link_adr_req);
+    // send a radio event to let the radio device indicate a packet was received
+    let response = device.handle_event(Event::RadioEvent(radio::Event::PhyEvent(()))).unwrap();
+    assert!(matches!(response, Response::DownlinkReceived(0)));
+    // send another uplink which should carry the LinkAdrAns
+    let response = device.send(&[0; 1], 1, true).unwrap();
+    assert!(matches!(response, Response::TimeoutRequest(1000)));
+    let response = device.handle_event(Event::TimeoutFired).unwrap(); // begin Rx1
+    assert!(matches!(response, Response::TimeoutRequest(1100)));
+    device.get_radio().set_rxtx_handler(handle_data_uplink_with_link_adr_ans);
+    // send a radio event to let the radio device indicate a packet was received
+    let response = device.handle_event(Event::RadioEvent(radio::Event::PhyEvent(()))).unwrap();
+    assert!(matches!(response, Response::DownlinkReceived(1)));
+}

--- a/device/src/state_machines/test/util.rs
+++ b/device/src/state_machines/test/util.rs
@@ -1,0 +1,95 @@
+use super::*;
+use crate::radio::{Error, Event, Response, RfConfig, RxQuality};
+use crate::test_util::*;
+use crate::{radio::PhyRxTx, Device, Timings};
+use lorawan::default_crypto;
+use region::{Configuration, Region};
+
+pub fn test_device(
+    join_mode: JoinMode,
+) -> Device<TestRadio, default_crypto::DefaultFactory, rand_core::OsRng, 255> {
+    Device::new(
+        Configuration::new(Region::US915),
+        join_mode,
+        TestRadio::default(),
+        rand::rngs::OsRng,
+    )
+}
+
+pub struct TestRadio {
+    current_config: Option<RfConfig>,
+    last_uplink: Option<Uplink>,
+    rxtx_handler: Option<RxTxHandler>,
+    buffer: [u8; 256],
+    buffer_index: usize,
+}
+
+impl TestRadio {
+    pub fn set_rxtx_handler(&mut self, handler: RxTxHandler) {
+        self.rxtx_handler = Some(handler);
+    }
+}
+
+impl Default for TestRadio {
+    fn default() -> Self {
+        Self {
+            current_config: None,
+            last_uplink: None,
+            rxtx_handler: None,
+            buffer: [0; 256],
+            buffer_index: 0,
+        }
+    }
+}
+
+impl PhyRxTx for TestRadio {
+    type PhyEvent = ();
+    type PhyError = &'static str;
+    type PhyResponse = ();
+
+    fn get_mut_radio(&mut self) -> &mut Self {
+        self
+    }
+    fn get_received_packet(&mut self) -> &mut [u8] {
+        &mut self.buffer[..self.buffer_index]
+    }
+
+    fn handle_event(&mut self, event: Event<Self>) -> Result<Response<Self>, Error<Self::PhyError>>
+    where
+        Self: Sized,
+    {
+        match event {
+            Event::TxRequest(config, buf) => {
+                // ensure that we have always consumed the previous uplink
+                if self.last_uplink.is_some() {
+                    return Err(Error::PhyError("Radio already has an uplink"));
+                }
+                self.last_uplink = Some(Uplink::new(&buf, config).map_err(|e| Error::PhyError(e))?);
+                return Ok(Response::TxDone(0));
+            }
+            Event::RxRequest(rf_config) => {
+                self.current_config = Some(rf_config);
+            }
+            Event::CancelRx => (),
+            Event::PhyEvent(()) => {
+                if let (Some(rf_config), Some(rxtx_handler)) =
+                    (self.current_config, self.rxtx_handler)
+                {
+                    self.buffer_index =
+                        rxtx_handler(self.last_uplink.take(), rf_config, &mut self.buffer);
+                    return Ok(Response::RxDone(RxQuality::new(0, 0)));
+                }
+            }
+        }
+        Ok(Response::Idle)
+    }
+}
+
+impl Timings for TestRadio {
+    fn get_rx_window_offset_ms(&self) -> i32 {
+        0
+    }
+    fn get_rx_window_duration_ms(&self) -> u32 {
+        100
+    }
+}

--- a/device/src/test_util.rs
+++ b/device/src/test_util.rs
@@ -1,0 +1,174 @@
+use super::*;
+use lorawan::maccommands::{ChannelMask, SerializableMacCommand};
+use lorawan::parser::DataHeader;
+use lorawan::{
+    default_crypto::DefaultFactory,
+    maccommandcreator::LinkADRReqCreator,
+    maccommands::{LinkADRReqPayload, MacCommand},
+    parser::{parse, DataPayload, PhyPayload},
+};
+use radio::{RfConfig, TxConfig};
+use std::vec::Vec;
+
+/// This module contains some functions for both async device and state machine driven devices
+/// to operate unit tests.
+///
+
+pub struct Uplink {
+    data: Vec<u8>,
+    #[allow(unused)]
+    tx_config: TxConfig,
+}
+
+impl Uplink {
+    /// Creates a copy from a reference and ensures the packet is at least parseable.
+    pub fn new(data_in: &[u8], tx_config: TxConfig) -> Result<Self, &'static str> {
+        let mut data: Vec<u8> = Vec::new();
+        data.extend_from_slice(data_in);
+        let _parse = parse(data.as_mut_slice())?;
+        Ok(Self { data, tx_config: tx_config })
+    }
+
+    pub fn get_payload(&mut self) -> PhyPayload<&mut [u8], DefaultFactory> {
+        // unwrap since we verified parse in new
+        parse(self.data.as_mut_slice()).unwrap()
+    }
+}
+
+/// Test functions shared by async_device and no_async_device tests
+pub fn get_key() -> [u8; 16] {
+    [0; 16]
+}
+
+pub fn get_dev_addr() -> DevAddr<[u8; 4]> {
+    DevAddr::from(0)
+}
+pub fn get_otaa_credentials() -> JoinMode {
+    JoinMode::OTAA { deveui: [0; 8], appeui: [0; 8], appkey: get_key() }
+}
+
+pub fn get_abp_credentials() -> JoinMode {
+    JoinMode::ABP {
+        devaddr: get_dev_addr(),
+        appskey: AES128(get_key()),
+        newskey: AES128(get_key()),
+    }
+}
+
+pub type RxTxHandler = fn(Option<Uplink>, RfConfig, &mut [u8]) -> usize;
+
+/// Handle join request and pack a JoinAccept into RxBuffer
+pub fn handle_join_request(
+    uplink: Option<Uplink>,
+    _config: RfConfig,
+    rx_buffer: &mut [u8],
+) -> usize {
+    if let Some(mut uplink) = uplink {
+        if let PhyPayload::JoinRequest(join_request) = uplink.get_payload() {
+            assert!(join_request.validate_mic(&AES128(get_key())));
+            let mut buffer: [u8; 17] = [0; 17];
+            let mut phy = lorawan::creator::JoinAcceptCreator::with_options(
+                &mut buffer,
+                DefaultFactory::default(),
+            )
+            .unwrap();
+            let app_nonce_bytes = [1; 3];
+            phy.set_app_nonce(&app_nonce_bytes);
+            phy.set_net_id(&[1; 3]);
+            phy.set_dev_addr(get_dev_addr());
+            let finished = phy.build(&AES128(get_key())).unwrap();
+            rx_buffer[..finished.len()].copy_from_slice(&finished);
+            return finished.len();
+        }
+    }
+    0
+}
+
+/// Handle an uplink and respond with two LinkAdrReq on Port 0
+pub fn handle_data_uplink_with_link_adr_req(
+    uplink: Option<Uplink>,
+    _config: RfConfig,
+    rx_buffer: &mut [u8],
+) -> usize {
+    if let Some(mut uplink) = uplink {
+        if let PhyPayload::Data(DataPayload::Encrypted(data)) = uplink.get_payload() {
+            let fcnt = data.fhdr().fcnt() as u32;
+            assert!(data.validate_mic(&AES128(get_key()), fcnt));
+            let uplink =
+                data.decrypt(Some(&AES128(get_key())), Some(&AES128(get_key())), fcnt).unwrap();
+            assert_eq!(uplink.fhdr().fcnt(), 0);
+            let mac_cmds = [link_adr_req_with_bank_ctrl(0b10), link_adr_req_with_bank_ctrl(0b100)];
+            let mac_cmds = [
+                // drop the CID byte when building the MAC Command (ie: [1..])
+                MacCommand::LinkADRReq(LinkADRReqPayload::new(&mac_cmds[0].build()[1..]).unwrap()),
+                MacCommand::LinkADRReq(LinkADRReqPayload::new(&mac_cmds[1].build()[1..]).unwrap()),
+            ];
+            let cmd: Vec<&dyn SerializableMacCommand> = vec![&mac_cmds[0], &mac_cmds[1]];
+
+            let mut phy = lorawan::creator::DataPayloadCreator::with_options(
+                rx_buffer,
+                DefaultFactory::default(),
+            )
+            .unwrap();
+            phy.set_confirmed(uplink.is_confirmed());
+            phy.set_dev_addr(&[0; 4]);
+            phy.set_uplink(false);
+            let finished = phy.build(&[], &cmd, &AES128(get_key()), &AES128(get_key())).unwrap();
+            return finished.len();
+        }
+    }
+    0
+}
+
+fn link_adr_req_with_bank_ctrl(cm: u16) -> LinkADRReqCreator {
+    // prepare a confirmed downlink
+    let mut adr_req = LinkADRReqCreator::new();
+    adr_req.set_data_rate(0).unwrap();
+    adr_req.set_tx_power(0).unwrap();
+    // this should give us a chmask ctrl value of 5 which allows us to turn banks on and off
+    adr_req.set_redundancy(0x50);
+    // the second bit is the only high bit, so only bank 2 should be enabled
+    let mut tmp = [cm as u8, (cm >> 8) as u8];
+    let cm = ChannelMask::new(&mut tmp).unwrap();
+    adr_req.set_channel_mask(cm);
+    adr_req
+}
+
+/// Looks for LinkAdrAns
+pub fn handle_data_uplink_with_link_adr_ans(
+    uplink: Option<Uplink>,
+    _config: RfConfig,
+    rx_buffer: &mut [u8],
+) -> usize {
+    if let Some(mut uplink) = uplink {
+        if let PhyPayload::Data(DataPayload::Encrypted(data)) = uplink.get_payload() {
+            let fcnt = data.fhdr().fcnt() as u32;
+            assert!(data.validate_mic(&AES128(get_key()), fcnt));
+            let uplink =
+                data.decrypt(Some(&AES128(get_key())), Some(&AES128(get_key())), fcnt).unwrap();
+            let fhdr = uplink.fhdr();
+            let mac_cmds: Vec<MacCommand> = fhdr.fopts().collect();
+
+            assert_eq!(mac_cmds.len(), 2);
+            assert!(matches!(mac_cmds[0], MacCommand::LinkADRAns(_)));
+            assert!(matches!(mac_cmds[1], MacCommand::LinkADRAns(_)));
+
+            // Build the actual data payload with FPort 0 which allows MAC Commands in payload
+            rx_buffer.iter_mut().for_each(|x| *x = 0);
+            let mut phy = lorawan::creator::DataPayloadCreator::with_options(
+                rx_buffer,
+                DefaultFactory::default(),
+            )
+            .unwrap();
+            phy.set_confirmed(uplink.is_confirmed());
+            phy.set_dev_addr(&[0; 4]);
+            phy.set_uplink(false);
+            //phy.set_f_port(3);
+            phy.set_fcnt(1);
+            // zero out rx_buffer
+            let finished = phy.build(&[], &[], &AES128(get_key()), &AES128(get_key())).unwrap();
+            return finished.len();
+        }
+    }
+    0
+}

--- a/encoding/src/creator.rs
+++ b/encoding/src/creator.rs
@@ -479,6 +479,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> DataPayloadCreator<D, F> {
 
         // Set FPort
         let mut payload_len = payload.len();
+
         if has_fport_zero && payload_len > 0 {
             return Err("mac commands in payload can not be send together with payload");
         }
@@ -495,6 +496,7 @@ impl<D: AsMut<[u8]>, F: CryptoFactory + Default> DataPayloadCreator<D, F> {
             .unwrap();
             last_filled += mac_cmds_len;
         }
+
         if has_fport {
             d[last_filled] = self.data_f_port.unwrap();
             last_filled += 1;

--- a/encoding/src/maccommandcreator.rs
+++ b/encoding/src/maccommandcreator.rs
@@ -720,10 +720,12 @@ pub fn build_mac_commands<'a, T: AsMut<[u8]>>(
     }
     let mut i = 0;
     for mc in cmds {
+        // prefix the CID
         res[i] = mc.cid();
-        let l = mc.payload_len();
-        res[i + 1..i + l + 1].copy_from_slice(mc.payload_bytes());
-        i += l + 1;
+        let start = i + 1;
+        let end = start + mc.payload_len();
+        res[start..end].copy_from_slice(mc.payload_bytes());
+        i = end;
     }
     Ok(i)
 }

--- a/encoding/src/maccommands.rs
+++ b/encoding/src/maccommands.rs
@@ -444,6 +444,12 @@ impl<'a> LinkADRReqPayload<'a> {
     }
 }
 
+impl<'a> From<&'a [u8; 4]> for LinkADRReqPayload<'a> {
+    fn from(v: &'a [u8; 4]) -> Self {
+        LinkADRReqPayload(v)
+    }
+}
+
 /// ChannelMask represents the ChannelMask from LoRaWAN.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChannelMask<const N: usize>([u8; N]);

--- a/encoding/src/parser.rs
+++ b/encoding/src/parser.rs
@@ -948,6 +948,12 @@ impl From<DevAddr<[u8; 4]>> for u32 {
     }
 }
 
+impl From<u32> for DevAddr<[u8; 4]> {
+    fn from(v: u32) -> Self {
+        DevAddr([(v >> 24) as u8, (v >> 16) as u8, (v >> 8) as u8, v as u8])
+    }
+}
+
 fixed_len_struct! {
     /// NwkAddr represents a 24 bit network address.
     struct NwkAddr[3];
@@ -991,7 +997,9 @@ impl<'a> FHDR<'a> {
     /// Gives the piggy-backed MAC ommands associated with the given payload.
     pub fn fopts(&self) -> MacCommandIterator {
         let f_opts_len = FCtrl(self.0[4], self.1).f_opts_len();
-        parse_mac_commands(&self.0[7_usize..(7 + f_opts_len) as usize], self.1)
+        let start = 7;
+        let end = 7 + f_opts_len as usize;
+        parse_mac_commands(&self.0[start..end], self.1)
     }
 }
 


### PR DESCRIPTION
Some pieces from the `async_device` unit tests are refactored into the `lorawan_device::test_utils` module.

The `state_machine` device is tested almost completely now and a few bugs were even found, such as

```rust
Response::NoAck => crate::Response::NoUpdate,
```
should've been 
```rust
Response::NoAck => crate::Response::NoAck
```

And WaitingForRx was not transitioning `into_idle` after receiving the downlink successfully.

Some small changes were made to encoding, but should be non-substantive (just trying to improve readability). Plus some simple type conversions.