### PR TITLE
Expand async unit tests

### DIFF
--- a/device/src/async_device/test/mod.rs
+++ b/device/src/async_device/test/mod.rs
@@ -5,29 +5,20 @@ use crate::{
     test_util::*,
 };
 use lorawan::default_crypto::DefaultFactory;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 mod timer;
-use timer::{TestTimer, TimerChannel};
+use timer::TestTimer;
 
 mod radio;
-use radio::{RadioChannel, TestRadio};
+use radio::TestRadio;
+
+mod util;
+use util::{setup, setup_with_session};
 
 type Device =
     crate::async_device::Device<TestRadio, DefaultFactory, TestTimer, rand_core::OsRng, 512>;
-
-fn setup() -> (RadioChannel, TimerChannel, Device) {
-    let (radio_channel, mock_radio) = TestRadio::new();
-    let (timer_channel, mock_timer) = TestTimer::new();
-    let region = region::US915::default();
-    let async_device: crate::async_device::Device<
-        TestRadio,
-        DefaultFactory,
-        TestTimer,
-        rand_core::OsRng,
-        512,
-    > = Device::new(region.into(), mock_radio, mock_timer, rand::rngs::OsRng);
-    (radio_channel, timer_channel, async_device)
-}
 
 #[tokio::test]
 async fn test_join_rx1() {
@@ -115,5 +106,169 @@ async fn test_noise() {
         assert!(true);
     } else {
         assert!(false);
+    }
+}
+
+#[tokio::test]
+async fn test_unconfirmed_uplink_no_downlink() {
+    let (_radio, timer, mut async_device) = setup_with_session();
+    let send_await_complete = Arc::new(Mutex::new(false));
+
+    // Run the device
+    let complete = send_await_complete.clone();
+    let async_device = tokio::spawn(async move {
+        let response = async_device.send(&[1, 2, 3], 3, false).await;
+
+        let mut complete = complete.lock().await;
+        *complete = true;
+        response
+    });
+    // Trigger beginning of RX1
+    timer.fire().await;
+    assert!(!*send_await_complete.lock().await);
+    // Trigger end of RX1
+    timer.fire().await;
+    assert!(!*send_await_complete.lock().await);
+    // Trigger start of RX2
+    timer.fire().await;
+    assert!(!*send_await_complete.lock().await);
+    // Trigger end of RX2
+    timer.fire().await;
+
+    match async_device.await.unwrap() {
+        Err(Error::RxTimeout) => (),
+        _ => assert!(false),
+    }
+    assert!(*send_await_complete.lock().await);
+}
+
+#[tokio::test]
+async fn test_confirmed_uplink_no_ack() {
+    let (_radio, timer, mut async_device) = setup_with_session();
+    let send_await_complete = Arc::new(Mutex::new(false));
+
+    // Run the device
+    let complete = send_await_complete.clone();
+    let async_device = tokio::spawn(async move {
+        let response = async_device.send(&[1, 2, 3], 3, true).await;
+
+        let mut complete = complete.lock().await;
+        *complete = true;
+        response
+    });
+    // Trigger beginning of RX1
+    timer.fire().await;
+    assert!(!*send_await_complete.lock().await);
+    // Trigger end of RX1
+    timer.fire().await;
+    assert!(!*send_await_complete.lock().await);
+    // Trigger start of RX2
+    timer.fire().await;
+    assert!(!*send_await_complete.lock().await);
+    // Trigger end of RX2
+    timer.fire().await;
+
+    match async_device.await.unwrap() {
+        // TODO: implement some ACK failure notification. This response is
+        // currently identical to taht of an unconfirmed uplink.
+        Err(Error::RxTimeout) => (),
+        _ => assert!(false),
+    }
+    assert!(*send_await_complete.lock().await);
+}
+
+#[tokio::test]
+async fn test_confirmed_uplink_with_ack_rx1() {
+    let (radio, timer, mut async_device) = setup_with_session();
+    let send_await_complete = Arc::new(Mutex::new(false));
+
+    // Run the device
+    let complete = send_await_complete.clone();
+    let async_device = tokio::spawn(async move {
+        let response = async_device.send(&[1, 2, 3], 3, true).await;
+
+        let mut complete = complete.lock().await;
+        *complete = true;
+        response
+    });
+    // Trigger beginning of RX1
+    timer.fire().await;
+    assert!(!*send_await_complete.lock().await);
+
+    // Send a downlink with confirmation
+    radio.handle_rxtx(handle_data_uplink_with_link_adr_req);
+    match async_device.await.unwrap() {
+        Ok(()) => (),
+        _ => {
+            assert!(false)
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_confirmed_uplink_with_ack_rx2() {
+    let (radio, timer, mut async_device) = setup_with_session();
+    let send_await_complete = Arc::new(Mutex::new(false));
+
+    // Run the device
+    let complete = send_await_complete.clone();
+    let async_device = tokio::spawn(async move {
+        let response = async_device.send(&[1, 2, 3], 3, true).await;
+
+        let mut complete = complete.lock().await;
+        *complete = true;
+        response
+    });
+    // Trigger beginning of RX1
+    timer.fire().await;
+    assert!(!*send_await_complete.lock().await);
+    // Trigger end of RX1
+    timer.fire().await;
+    assert!(!*send_await_complete.lock().await);
+    // Trigger start of RX2
+    timer.fire().await;
+
+    // Send a downlink confirmation
+    radio.handle_rxtx(handle_data_uplink_with_link_adr_req);
+
+    match async_device.await.unwrap() {
+        Ok(()) => (),
+        _ => {
+            assert!(false)
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_link_adr_ans() {
+    let (radio, timer, mut async_device) = setup_with_session();
+    let send_await_complete = Arc::new(Mutex::new(false));
+
+    // Run the device
+    let complete = send_await_complete.clone();
+    let async_device = tokio::spawn(async move {
+        async_device.send(&[1, 2, 3], 3, true).await.unwrap();
+        {
+            let mut complete = complete.lock().await;
+            *complete = true;
+        }
+        async_device.send(&[1, 2, 3], 3, true).await
+    });
+    // Trigger beginning of RX1
+    timer.fire().await;
+    // Send a downlink with confirmation
+    radio.handle_rxtx(handle_data_uplink_with_link_adr_req);
+    tokio::time::sleep(tokio::time::Duration::from_millis(15)).await;
+    assert!(*send_await_complete.lock().await);
+    // at this point, the device thread should be sending the second frame
+    // Trigger beginning of RX1
+    timer.fire().await;
+    // Send a downlink with confirmation
+    radio.handle_rxtx(handle_data_uplink_with_link_adr_ans);
+    match async_device.await.unwrap() {
+        Ok(()) => (),
+        _ => {
+            assert!(false)
+        }
     }
 }

--- a/device/src/async_device/test/radio.rs
+++ b/device/src/async_device/test/radio.rs
@@ -49,7 +49,7 @@ impl PhyRxTx for TestRadio {
         let handler = self.rx.recv().await.unwrap();
         let mut last_uplink = self.last_uplink.lock().await;
         // a quick yield to let timer arm
-        time::sleep(time::Duration::from_millis(50)).await;
+        time::sleep(time::Duration::from_millis(5)).await;
         if let Some(config) = &self.current_config {
             let size = handler(last_uplink.take(), *config, receiving_buffer);
             Ok((size, RxQuality::new(0, 0)))

--- a/device/src/async_device/test/util.rs
+++ b/device/src/async_device/test/util.rs
@@ -1,0 +1,38 @@
+use super::{get_dev_addr, get_key, radio::*, region, timer::*, DefaultFactory, Device};
+
+use crate::async_device::SessionData;
+use crate::{AppSKey, NewSKey};
+
+fn setup_internal(session_data: Option<SessionData>) -> (RadioChannel, TimerChannel, Device) {
+    let (radio_channel, mock_radio) = TestRadio::new();
+    let (timer_channel, mock_timer) = TestTimer::new();
+    let region = region::US915::default();
+    let async_device: crate::async_device::Device<
+        TestRadio,
+        DefaultFactory,
+        TestTimer,
+        rand_core::OsRng,
+        512,
+    > = Device::new_with_session(
+        region.into(),
+        mock_radio,
+        mock_timer,
+        rand::rngs::OsRng,
+        session_data,
+    );
+    (radio_channel, timer_channel, async_device)
+}
+
+pub fn setup_with_session() -> (RadioChannel, TimerChannel, Device) {
+    setup_internal(Some(SessionData {
+        newskey: NewSKey::from(get_key()),
+        appskey: AppSKey::from(get_key()),
+        devaddr: get_dev_addr(),
+        fcnt_up: 0,
+        fcnt_down: 0,
+    }))
+}
+
+pub fn setup() -> (RadioChannel, TimerChannel, Device) {
+    setup_internal(None)
+}


### PR DESCRIPTION
This leverages some helper functions from the state_machine unit tests to cover additional features in the async_device.