### PR TITLE
prepare release

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorawan-device"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Louis Thiery <thiery.louis@gmail.com>", "Ulf Lilleengen <lulf@redhat.com>"]
 edition = "2018"
 categories = [
@@ -11,10 +11,11 @@ categories = [
 license = "Apache-2.0"
 readme = "README.md"
 description = "A Rust LoRaWAN device stack implementation"
+repository = "https://github.com/ivajloip/rust-lorawan"
 
 [dependencies]
 lora-modulation = { version = ">=0.1.2", default-features = false }
-lorawan = { version = "0.7.3", path = "../encoding", default-features = false }
+lorawan = { version = "0.7.4", path = "../encoding", default-features = false }
 heapless = "0.7"
 generic-array = "0.14.2"
 defmt = { version = "0.3", optional = true }

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lorawan"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2018"
 authors = ["Ivaylo Petrov <ivajloip@gmail.com>"]
 description = "Crate lorawan provides structures and tools for reading and writing LoRaWAN messages from and to a slice of bytes."


### PR DESCRIPTION
Prepare a tag release so that embassy examples may depend on release instead of git hash.

I don't think we've made any API changes to the encoding side of things, so just a patch release there. For the lorawan-device, there have been significant API changes so I bumped a minor release since we are pre-1.0.
