### PR TITLE
Fix bug in async_device::Device implementation

### DIFF
--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -85,7 +85,7 @@ enum RxWindowResponse<F: futures::Future<Output = ()> + Sized + Unpin> {
 
 impl<R, C, T, const N: usize> Device<R, C, T, rng::Prng, N>
 where
-    R: radio::PhyRxTx + Timings + RngCore,
+    R: radio::PhyRxTx + Timings,
     C: CryptoFactory + Default,
     T: radio::Timer,
 {

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -26,6 +26,7 @@ use lorawan::{
 
 pub use rand_core::RngCore;
 mod rng;
+pub use rng::Prng;
 
 #[cfg(feature = "async")]
 pub mod async_device;

--- a/device/src/rng.rs
+++ b/device/src/rng.rs
@@ -23,10 +23,10 @@ use fastrand::Rng;
 use rand_core::RngCore;
 
 #[derive(Clone)]
-pub(crate) struct Prng(Rng);
+pub struct Prng(Rng);
 
 impl Prng {
-    pub fn new(seed: u64) -> Self {
+    pub(crate) fn new(seed: u64) -> Self {
         Self(Rng::with_seed(seed))
     }
 }


### PR DESCRIPTION
The requirement for the RadioKind to implement `RngCore` had been mistakenly left in #151. Fix that quickly. Also make `Prng` type public so that it can be named in downstream crates.