### PR TITLE
Extract some generic utilities from the Preamble detection branch

### DIFF
--- a/device/src/async_device/lora_radio.rs
+++ b/device/src/async_device/lora_radio.rs
@@ -72,9 +72,9 @@ where
 
     async fn tx(&mut self, config: TxConfig, buffer: &[u8]) -> Result<u32, Self::PhyError> {
         let mdltn_params = self.lora.create_modulation_params(
-            config.rf.spreading_factor,
-            config.rf.bandwidth,
-            config.rf.coding_rate,
+            config.rf.bb.sf,
+            config.rf.bb.bw,
+            config.rf.bb.cr,
             config.rf.frequency,
         )?;
         let mut tx_pkt_params =
@@ -96,9 +96,9 @@ where
 
     async fn setup_rx(&mut self, config: RfConfig) -> Result<(), Self::PhyError> {
         let mdltn_params = self.lora.create_modulation_params(
-            config.spreading_factor,
-            config.bandwidth,
-            config.coding_rate,
+            config.bb.sf,
+            config.bb.bw,
+            config.bb.cr,
             config.frequency,
         )?;
         let rx_pkt_params =

--- a/device/src/async_device/radio.rs
+++ b/device/src/async_device/radio.rs
@@ -1,4 +1,4 @@
-pub use crate::radio::{Bandwidth, CodingRate, RfConfig, RxQuality, SpreadingFactor, TxConfig};
+pub use crate::radio::{RfConfig, RxQuality, TxConfig};
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Error<E>(pub E);

--- a/device/src/radio.rs
+++ b/device/src/radio.rs
@@ -1,12 +1,10 @@
-pub use ::lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
+use lora_modulation::BaseBandModulationParams;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RfConfig {
     pub frequency: u32,
-    pub bandwidth: Bandwidth,
-    pub spreading_factor: SpreadingFactor,
-    pub coding_rate: CodingRate,
+    pub bb: BaseBandModulationParams,
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/device/src/region/constants.rs
+++ b/device/src/region/constants.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use crate::radio::{Bandwidth, CodingRate, SpreadingFactor};
+use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 
 pub(crate) const RECEIVE_DELAY1: u32 = 1000;
 pub(crate) const RECEIVE_DELAY2: u32 = RECEIVE_DELAY1 + 1000; // must be RECEIVE_DELAY + 1 s

--- a/device/src/region/dynamic_channel_plans/as923.rs
+++ b/device/src/region/dynamic_channel_plans/as923.rs
@@ -11,15 +11,19 @@ pub(crate) type AS923_4 = DynamicChannelPlan<2, 7, AS923Region<917_300_000, 5900
 #[allow(clippy::upper_case_acronyms)]
 pub struct AS923Region<const DEFAULT_RX2: u32, const O: u32>;
 
+impl<const DEFAULT_RX2: u32, const OFFSET: u32> ChannelRegion<7>
+    for AS923Region<DEFAULT_RX2, OFFSET>
+{
+    fn datarates() -> &'static [Option<Datarate>; 7] {
+        &DATARATES
+    }
+}
+
 impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2, 7>
-    for AS923Region<OFFSET, DEFAULT_RX2>
+    for AS923Region<DEFAULT_RX2, OFFSET>
 {
     fn join_channels() -> [u32; 2] {
         [JOIN_CHANNELS[0] + OFFSET, JOIN_CHANNELS[1] + OFFSET]
-    }
-
-    fn datarates() -> &'static [Option<Datarate>; 7] {
-        &DATARATES
     }
 
     fn get_default_rx2() -> u32 {
@@ -30,12 +34,47 @@ impl<const DEFAULT_RX2: u32, const OFFSET: u32> DynamicChannelRegion<2, 7>
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 7] = [
-    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_250KHz }),
-    //ignore FSK data rate for now
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_12,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 0,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_11,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 0,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_10,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 123,
+        max_mac_payload_size_with_dwell_time: 19,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_9,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 123,
+        max_mac_payload_size_with_dwell_time: 61,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 133,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_250KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    // TODO: ignore FSK data rate for now
 ];

--- a/device/src/region/dynamic_channel_plans/eu433.rs
+++ b/device/src/region/dynamic_channel_plans/eu433.rs
@@ -9,13 +9,15 @@ pub(crate) type EU433 = DynamicChannelPlan<3, 7, EU433Region>;
 #[allow(clippy::upper_case_acronyms)]
 pub struct EU433Region;
 
+impl ChannelRegion<7> for EU433Region {
+    fn datarates() -> &'static [Option<Datarate>; 7] {
+        &DATARATES
+    }
+}
+
 impl DynamicChannelRegion<3, 7> for EU433Region {
     fn join_channels() -> [u32; 3] {
         JOIN_CHANNELS
-    }
-
-    fn datarates() -> &'static [Option<Datarate>; 7] {
-        &DATARATES
     }
 
     fn get_default_rx2() -> u32 {
@@ -26,11 +28,47 @@ impl DynamicChannelRegion<3, 7> for EU433Region {
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 7] = [
-    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_250KHz }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_12,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 0,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_11,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 0,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_10,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 123,
+        max_mac_payload_size_with_dwell_time: 19,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_9,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 123,
+        max_mac_payload_size_with_dwell_time: 61,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 133,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_250KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    // TODO 7 is defined in rp002-1-0-4
 ];

--- a/device/src/region/dynamic_channel_plans/eu868.rs
+++ b/device/src/region/dynamic_channel_plans/eu868.rs
@@ -9,13 +9,15 @@ pub(crate) type EU868 = DynamicChannelPlan<3, 7, EU868Region>;
 #[allow(clippy::upper_case_acronyms)]
 pub struct EU868Region;
 
+impl ChannelRegion<7> for EU868Region {
+    fn datarates() -> &'static [Option<Datarate>; 7] {
+        &DATARATES
+    }
+}
+
 impl DynamicChannelRegion<3, 7> for EU868Region {
     fn join_channels() -> [u32; 3] {
         JOIN_CHANNELS
-    }
-
-    fn datarates() -> &'static [Option<Datarate>; 7] {
-        &DATARATES
     }
 
     fn get_default_rx2() -> u32 {
@@ -26,12 +28,47 @@ impl DynamicChannelRegion<3, 7> for EU868Region {
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 7] = [
-    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_250KHz }),
-    //ignore FSK data rate for now
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_12,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 59,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_11,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 59,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_10,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 59,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_9,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 123,
+        max_mac_payload_size_with_dwell_time: 123,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_250KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    // TODO: ignore FSK data rate for now
 ];

--- a/device/src/region/dynamic_channel_plans/in865.rs
+++ b/device/src/region/dynamic_channel_plans/in865.rs
@@ -9,13 +9,15 @@ pub(crate) type IN865 = DynamicChannelPlan<3, 6, IN865Region>;
 #[allow(clippy::upper_case_acronyms)]
 pub struct IN865Region;
 
+impl ChannelRegion<6> for IN865Region {
+    fn datarates() -> &'static [Option<Datarate>; 6] {
+        &DATARATES
+    }
+}
+
 impl DynamicChannelRegion<3, 6> for IN865Region {
     fn join_channels() -> [u32; 3] {
         JOIN_CHANNELS
-    }
-
-    fn datarates() -> &'static [Option<Datarate>; 6] {
-        &DATARATES
     }
 
     fn get_default_rx2() -> u32 {
@@ -26,11 +28,41 @@ impl DynamicChannelRegion<3, 6> for IN865Region {
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 6] = [
-    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
-    //ignore FSK data rate for now
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_12,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 59,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_11,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 59,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_10,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 59,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_9,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 123,
+        max_mac_payload_size_with_dwell_time: 123,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    // TODO: ignore FSK data rate for now
 ];

--- a/device/src/region/dynamic_channel_plans/mod.rs
+++ b/device/src/region/dynamic_channel_plans/mod.rs
@@ -64,11 +64,16 @@ impl<
         };
         (rng.next_u32() as usize) & cm
     }
+
+    pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
+        R::get_max_payload_length(datarate, repeater_compatible, dwell_time)
+    }
 }
 
-pub(crate) trait DynamicChannelRegion<const NUM_JOIN_CHANNELS: usize, const NUM_DATARATES: usize> {
+pub(crate) trait DynamicChannelRegion<const NUM_JOIN_CHANNELS: usize, const NUM_DATARATES: usize>:
+    ChannelRegion<NUM_DATARATES>
+{
     fn join_channels() -> [u32; NUM_JOIN_CHANNELS];
-    fn datarates() -> &'static [Option<Datarate>; NUM_DATARATES];
     fn get_default_rx2() -> u32;
 }
 

--- a/device/src/region/fixed_channel_plans/au915/datarates.rs
+++ b/device/src/region/fixed_channel_plans/au915/datarates.rs
@@ -1,20 +1,85 @@
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 16] = [
-    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_500KHz }),
-    None, // LR-FHSS -- not currently supported
-    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_500KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_500KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_500KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_500KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_500KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_500KHz }),
-    None, // RFU
-    None,
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_12,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 0,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_11,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 0,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_10,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 59,
+        max_mac_payload_size_with_dwell_time: 19,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_9,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 123,
+        max_mac_payload_size_with_dwell_time: 61,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 133,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    None, // LR-FHSS -- not currently supported, TODO: defined in rp002-1-0-4
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_12,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 61,
+        max_mac_payload_size_with_dwell_time: 61,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_11,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 137,
+        max_mac_payload_size_with_dwell_time: 137,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_10,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_9,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    None, // RFU, TODO: defined in rp002-1-0-4
+    None, // TODO: defined in rp002-1-0-4
 ];

--- a/device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/device/src/region/fixed_channel_plans/au915/mod.rs
@@ -33,13 +33,22 @@ const DEFAULT_RX2: u32 = 923_300_000;
 #[derive(Default, Clone)]
 pub struct AU915(pub(crate) FixedChannelPlan<16, AU915Region>);
 
+impl AU915 {
+    pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
+        AU915Region::get_max_payload_length(datarate, repeater_compatible, dwell_time)
+    }
+}
+
 #[derive(Default, Clone)]
 pub(crate) struct AU915Region;
 
-impl FixedChannelRegion<16> for AU915Region {
+impl ChannelRegion<16> for AU915Region {
     fn datarates() -> &'static [Option<Datarate>; 16] {
         &DATARATES
     }
+}
+
+impl FixedChannelRegion<16> for AU915Region {
     fn uplink_channels() -> &'static [u32; 72] {
         &UPLINK_CHANNEL_MAP
     }

--- a/device/src/region/fixed_channel_plans/mod.rs
+++ b/device/src/region/fixed_channel_plans/mod.rs
@@ -57,10 +57,13 @@ impl<const D: usize, F: FixedChannelRegion<D>> FixedChannelPlan<D, F> {
         self.channel_mask.set_bank(6, mask);
         self.channel_mask.set_bank(7, mask);
     }
+
+    pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
+        F::get_max_payload_length(datarate, repeater_compatible, dwell_time)
+    }
 }
 
-pub(crate) trait FixedChannelRegion<const NUM_DR: usize> {
-    fn datarates() -> &'static [Option<Datarate>; NUM_DR];
+pub(crate) trait FixedChannelRegion<const D: usize>: ChannelRegion<D> {
     fn uplink_channels() -> &'static [u32; 72];
     fn downlink_channels() -> &'static [u32; 8];
     fn get_default_rx2() -> u32;

--- a/device/src/region/fixed_channel_plans/us915/datarates.rs
+++ b/device/src/region/fixed_channel_plans/us915/datarates.rs
@@ -1,18 +1,73 @@
 use super::{Bandwidth, Datarate, SpreadingFactor};
 
 pub(crate) const DATARATES: [Option<Datarate>; 14] = [
-    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_125KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_10,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 19,
+        max_mac_payload_size_with_dwell_time: 19,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_9,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 61,
+        max_mac_payload_size_with_dwell_time: 61,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 133,
+        max_mac_payload_size_with_dwell_time: 133,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_125KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    None, // TODO: defined in rp002-1-0-4
+    None, // TODO: defined in rp002-1-0-4
     None,
-    None,
-    None,
-    Some(Datarate { spreading_factor: SpreadingFactor::_12, bandwidth: Bandwidth::_500KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_11, bandwidth: Bandwidth::_500KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_10, bandwidth: Bandwidth::_500KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_9, bandwidth: Bandwidth::_500KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_8, bandwidth: Bandwidth::_500KHz }),
-    Some(Datarate { spreading_factor: SpreadingFactor::_7, bandwidth: Bandwidth::_500KHz }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_12,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 61,
+        max_mac_payload_size_with_dwell_time: 61,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_11,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 137,
+        max_mac_payload_size_with_dwell_time: 137,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_10,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_9,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_8,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
+    Some(Datarate {
+        spreading_factor: SpreadingFactor::_7,
+        bandwidth: Bandwidth::_500KHz,
+        max_mac_payload_size: 250,
+        max_mac_payload_size_with_dwell_time: 250,
+    }),
 ];

--- a/device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/device/src/region/fixed_channel_plans/us915/mod.rs
@@ -33,13 +33,22 @@ const DEFAULT_RX2: u32 = 923_300_000;
 #[derive(Default, Clone)]
 pub struct US915(pub(crate) FixedChannelPlan<14, US915Region>);
 
+impl US915 {
+    pub fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
+        US915Region::get_max_payload_length(datarate, repeater_compatible, dwell_time)
+    }
+}
+
 #[derive(Default, Clone)]
 pub(crate) struct US915Region;
 
-impl FixedChannelRegion<14> for US915Region {
+impl ChannelRegion<14> for US915Region {
     fn datarates() -> &'static [Option<Datarate>; 14] {
         &DATARATES
     }
+}
+
+impl FixedChannelRegion<14> for US915Region {
     fn uplink_channels() -> &'static [u32; 72] {
         &UPLINK_CHANNEL_MAP
     }

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -1,6 +1,4 @@
-#![allow(clippy::upper_case_acronyms)]
-// generally, we allow upper_case_acronyms to make it match the LoRaWAN naming
-// conventions better
+use lora_modulation::{Bandwidth, BaseBandModulationParams, CodingRate, SpreadingFactor};
 use lorawan::{maccommands::ChannelMask, parser::CfList};
 use rand_core::RngCore;
 
@@ -183,9 +181,11 @@ impl Configuration {
             pw: self.get_dbm(),
             rf: RfConfig {
                 frequency,
-                bandwidth: dr.bandwidth,
-                spreading_factor: dr.spreading_factor,
-                coding_rate: self.get_coding_rate(),
+                bb: BaseBandModulationParams::new(
+                    dr.spreading_factor,
+                    dr.bandwidth,
+                    self.get_coding_rate(),
+                ),
             },
         }
     }
@@ -203,9 +203,11 @@ impl Configuration {
         let dr = self.get_rx_datarate(datarate, frame, window);
         RfConfig {
             frequency: self.get_rx_frequency(frame, window),
-            bandwidth: dr.bandwidth,
-            spreading_factor: dr.spreading_factor,
-            coding_rate: self.get_coding_rate(),
+            bb: BaseBandModulationParams::new(
+                dr.spreading_factor,
+                dr.bandwidth,
+                self.get_coding_rate(),
+            ),
         }
     }
 

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -20,6 +20,26 @@ mod fixed_channel_plans;
 
 pub use fixed_channel_plans::{Subband, AU915, US915};
 
+pub(crate) trait ChannelRegion<const D: usize> {
+    fn datarates() -> &'static [Option<Datarate>; D];
+
+    fn get_max_payload_length(datarate: DR, repeater_compatible: bool, dwell_time: bool) -> u8 {
+        let Some(Some(dr)) = Self::datarates().get(datarate as usize) else {
+            return 0;
+        };
+        let max_size = if dwell_time {
+            dr.max_mac_payload_size_with_dwell_time
+        } else {
+            dr.max_mac_payload_size
+        };
+        if repeater_compatible && max_size > 230 {
+            230
+        } else {
+            max_size
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Configuration {
     state: State,
@@ -102,6 +122,8 @@ impl State {
 pub struct Datarate {
     bandwidth: Bandwidth,
     spreading_factor: SpreadingFactor,
+    max_mac_payload_size: u8,
+    max_mac_payload_size_with_dwell_time: u8,
 }
 macro_rules! mut_region_dispatch {
   ($s:expr, $t:tt) => {
@@ -161,6 +183,35 @@ macro_rules! region_dispatch {
   };
 }
 
+macro_rules! region_static_dispatch {
+  ($s:expr, $t:tt) => {
+      match &$s.state {
+        State::AS923_1(_) => dynamic_channel_plans::AS923_1::$t(),
+        State::AS923_2(_) => dynamic_channel_plans::AS923_2::$t(),
+        State::AS923_3(_) => dynamic_channel_plans::AS923_3::$t(),
+        State::AS923_4(_) => dynamic_channel_plans::AS923_4::$t(),
+        State::AU915(_) => fixed_channel_plans::AU915::$t(),
+        State::EU868(_) => dynamic_channel_plans::EU868::$t(),
+        State::EU433(_) => dynamic_channel_plans::EU433::$t(),
+        State::IN865(_) => dynamic_channel_plans::IN865::$t(),
+        State::US915(_) => fixed_channel_plans::US915::$t(),
+    }
+  };
+  ($s:expr, $t:tt, $($arg:tt)*) => {
+      match &$s.state {
+        State::AS923_1(_) => dynamic_channel_plans::AS923_1::$t($($arg)*),
+        State::AS923_2(_) => dynamic_channel_plans::AS923_2::$t($($arg)*),
+        State::AS923_3(_) => dynamic_channel_plans::AS923_3::$t($($arg)*),
+        State::AS923_4(_) => dynamic_channel_plans::AS923_4::$t($($arg)*),
+        State::AU915(_) => fixed_channel_plans::AU915::$t($($arg)*),
+        State::EU868(_) => dynamic_channel_plans::EU868::$t($($arg)*),
+        State::EU433(_) => dynamic_channel_plans::EU433::$t($($arg)*),
+        State::IN865(_) => dynamic_channel_plans::IN865::$t($($arg)*),
+        State::US915(_) => fixed_channel_plans::US915::$t($($arg)*),
+    }
+  };
+}
+
 impl Configuration {
     pub fn new(region: Region) -> Configuration {
         Configuration::with_state(State::new(region))
@@ -168,6 +219,21 @@ impl Configuration {
 
     fn with_state(state: State) -> Configuration {
         Configuration { state }
+    }
+
+    pub fn get_max_payload_length(
+        &self,
+        datarate: DR,
+        repeater_compatible: bool,
+        dwell_time: bool,
+    ) -> u8 {
+        region_static_dispatch!(
+            self,
+            get_max_payload_length,
+            datarate,
+            repeater_compatible,
+            dwell_time
+        )
     }
 
     pub(crate) fn create_tx_config<RNG: RngCore>(


### PR DESCRIPTION
As the RX preamble detection branch #142  has suffered some bitrot due to some refactoring that has been merged meanwhile, I attempted to pull out some self-contained functionality into separate patches (hoping) to reduce overall patch delta:
1. Switch to BaseBandModulationParams in RxConfig
2. Functionality to calculate max payload for Configuration/Region

CC: @ilya-epifanov 