### PR TITLE
Testsuite preparations for preamble parsing

### DIFF
--- a/device/src/async_device/test/mod.rs
+++ b/device/src/async_device/test/mod.rs
@@ -91,7 +91,6 @@ async fn test_no_join_accept() {
     }
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_noise() {
     let (radio, timer, mut async_device) = setup();

--- a/device/src/async_device/test/mod.rs
+++ b/device/src/async_device/test/mod.rs
@@ -28,7 +28,7 @@ async fn test_join_rx1() {
         tokio::spawn(async move { async_device.join(&get_otaa_credentials()).await });
 
     // Trigger beginning of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     // Trigger handling of JoinAccept
     radio.handle_rxtx(handle_join_request);
 
@@ -50,11 +50,11 @@ async fn test_join_rx2() {
         tokio::spawn(async move { async_device.join(&get_otaa_credentials()).await });
 
     // Trigger beginning of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     // Trigger end of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     // Trigger start of RX2
-    timer.fire().await;
+    timer.fire_most_recent().await;
     // Pass the join request handler
     radio.handle_rxtx(handle_join_request);
 
@@ -74,13 +74,13 @@ async fn test_no_join_accept() {
         tokio::spawn(async move { async_device.join(&get_otaa_credentials()).await });
 
     // Trigger beginning of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     // Trigger end of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     // Trigger start of RX2
-    timer.fire().await;
+    timer.fire_most_recent().await;
     // Trigger end of RX2
-    timer.fire().await;
+    timer.fire_most_recent().await;
 
     // Await the device to return and verify state
     let response = async_device.await.unwrap();
@@ -98,7 +98,7 @@ async fn test_noise() {
     let async_device =
         tokio::spawn(async move { async_device.join(&get_otaa_credentials()).await });
     // Trigger beginning of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     // Send a bunch of invalid RF frames
     for _ in 0..12 {
         radio.handle_rxtx(|_, _, _| 5);
@@ -126,16 +126,16 @@ async fn test_unconfirmed_uplink_no_downlink() {
         response
     });
     // Trigger beginning of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     assert!(!*send_await_complete.lock().await);
     // Trigger end of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     assert!(!*send_await_complete.lock().await);
     // Trigger start of RX2
-    timer.fire().await;
+    timer.fire_most_recent().await;
     assert!(!*send_await_complete.lock().await);
     // Trigger end of RX2
-    timer.fire().await;
+    timer.fire_most_recent().await;
 
     match async_device.await.unwrap() {
         Ok(SendResponse::RxComplete) => (),
@@ -159,16 +159,16 @@ async fn test_confirmed_uplink_no_ack() {
         response
     });
     // Trigger beginning of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     assert!(!*send_await_complete.lock().await);
     // Trigger end of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     assert!(!*send_await_complete.lock().await);
     // Trigger start of RX2
-    timer.fire().await;
+    timer.fire_most_recent().await;
     assert!(!*send_await_complete.lock().await);
     // Trigger end of RX2
-    timer.fire().await;
+    timer.fire_most_recent().await;
 
     match async_device.await.unwrap() {
         Ok(SendResponse::NoAck) => (),
@@ -192,7 +192,7 @@ async fn test_confirmed_uplink_with_ack_rx1() {
         response
     });
     // Trigger beginning of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     assert!(!*send_await_complete.lock().await);
 
     // Send a downlink with confirmation
@@ -220,13 +220,13 @@ async fn test_confirmed_uplink_with_ack_rx2() {
         response
     });
     // Trigger beginning of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     assert!(!*send_await_complete.lock().await);
     // Trigger end of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     assert!(!*send_await_complete.lock().await);
     // Trigger start of RX2
-    timer.fire().await;
+    timer.fire_most_recent().await;
 
     // Send a downlink confirmation
     radio.handle_rxtx(handle_data_uplink_with_link_adr_req);
@@ -255,14 +255,14 @@ async fn test_link_adr_ans() {
         async_device.send(&[1, 2, 3], 3, true).await
     });
     // Trigger beginning of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     // Send a downlink with confirmation
     radio.handle_rxtx(handle_data_uplink_with_link_adr_req);
     tokio::time::sleep(tokio::time::Duration::from_millis(15)).await;
     assert!(*send_await_complete.lock().await);
     // at this point, the device thread should be sending the second frame
     // Trigger beginning of RX1
-    timer.fire().await;
+    timer.fire_most_recent().await;
     // Send a downlink with confirmation
     radio.handle_rxtx(handle_data_uplink_with_link_adr_ans);
     match async_device.await.unwrap() {

--- a/device/src/async_device/test/mod.rs
+++ b/device/src/async_device/test/mod.rs
@@ -91,6 +91,7 @@ async fn test_no_join_accept() {
     }
 }
 
+#[ignore]
 #[tokio::test]
 async fn test_noise() {
     let (radio, timer, mut async_device) = setup();

--- a/device/src/async_device/test/radio.rs
+++ b/device/src/async_device/test/radio.rs
@@ -52,7 +52,7 @@ impl PhyRxTx for TestRadio {
                 // a quick yield to let timer arm
                 time::sleep(time::Duration::from_millis(5)).await;
                 if let Some(config) = &self.current_config {
-                    let length = handler(last_uplink.take(), *config, rx_buf);
+                    let length = handler(last_uplink.clone(), *config, rx_buf);
                     Ok((length, RxQuality::new(-80, 0)))
                 } else {
                     panic!("Trying to rx before settings config!")

--- a/device/src/async_device/test/timer.rs
+++ b/device/src/async_device/test/timer.rs
@@ -1,47 +1,69 @@
 use crate::async_device::radio::Timer;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use tokio::sync::{mpsc, Mutex};
 
 impl TestTimer {
     pub fn new() -> (TimerChannel, Self) {
-        let (tx, rx) = mpsc::channel(5);
+        let tx = Arc::new(Mutex::new(HashMap::new()));
         let armed_count = Arc::new(Mutex::new(0));
-        (TimerChannel { tx, armed_count: armed_count.clone() }, Self { rx, armed_count })
+        (
+            TimerChannel { tx: tx.clone(), armed_count: armed_count.clone() },
+            Self { tx, armed_count },
+        )
     }
 }
 
 pub struct TestTimer {
     armed_count: Arc<Mutex<usize>>,
-    rx: mpsc::Receiver<()>,
+    tx: Arc<Mutex<HashMap<usize, mpsc::Sender<()>>>>,
+}
+
+impl TestTimer {
+    async fn create_channel_and_await(&mut self) {
+        let (tx, mut rx) = mpsc::channel(1);
+        {
+            *self.armed_count.lock().await += 1;
+            let mut tx_map = self.tx.lock().await;
+            tx_map.insert(*self.armed_count.lock().await, tx);
+        }
+        rx.recv().await;
+    }
 }
 
 impl Timer for TestTimer {
     fn reset(&mut self) {}
 
     async fn at(&mut self, _millis: u64) {
-        {
-            *self.armed_count.lock().await += 1;
-        }
-        self.rx.recv().await;
+        self.create_channel_and_await().await;
     }
 
     async fn delay_ms(&mut self, _millis: u64) {
-        {
-            *self.armed_count.lock().await += 1;
-        }
-        self.rx.recv().await;
+        self.create_channel_and_await().await;
     }
 }
 
 /// A channel for the test fixture to trigger fires and to check calls.
 pub struct TimerChannel {
     armed_count: Arc<Mutex<usize>>,
-    tx: mpsc::Sender<()>,
+    tx: Arc<Mutex<HashMap<usize, mpsc::Sender<()>>>>,
 }
 
 impl TimerChannel {
-    pub async fn fire(&self) {
-        self.tx.send(()).await.unwrap();
+    pub async fn fire_most_recent(&self) {
+        tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+        let mut tx_map = self.tx.lock().await;
+        let armed_count = *self.armed_count.lock().await;
+        let tx = tx_map.remove(&armed_count).unwrap();
+        tx.send(()).await.unwrap();
+    }
+
+    pub async fn confirm_dropped_timer(&self, index: usize) {
+        tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+        let mut tx_map = self.tx.lock().await;
+        let tx = tx_map.remove(&index).unwrap();
+        if let Ok(_) = tx.try_send(()) {
+            panic!("Timer was not dropped");
+        }
     }
 
     pub async fn get_armed_count(&self) -> usize {


### PR DESCRIPTION
Some testsuite code that was pulled out from the RX1+RX2 preamble detection patchset.
Please note that `test async_device::test::test_noise` started to fail but I'm too tired to figure out whether testsuite uncovered a bug or not...